### PR TITLE
Checking if resources are returned

### DIFF
--- a/NetScaler/Public/Get-NSLBMonitor.ps1
+++ b/NetScaler/Public/Get-NSLBMonitor.ps1
@@ -55,11 +55,15 @@ function Get-NSLBMonitor {
         if ($Name.Count -gt 0) {
             foreach ($item in $Name) {
                 $monitors = _InvokeNSRestApi -Session $Session -Method Get -Type lbmonitor -Action Get -Resource $item
-                return $monitors.lbmonitor
+                if ($monitors.psobject.properties.name -contains 'lbmonitor') {
+                    return $monitors.lbmonitor
+                }
             }
         } else {
             $monitors = _InvokeNSRestApi -Session $Session -Method Get -Type lbmonitor -Action Get
-            return $monitors.lbmonitor
+            if ($monitors.psobject.properties.name -contains 'lbmonitor') {
+                return $monitors.lbmonitor
+            }
         }
     }
 }

--- a/NetScaler/Public/Get-NSLBServer.ps1
+++ b/NetScaler/Public/Get-NSLBServer.ps1
@@ -56,12 +56,16 @@ function Get-NSLBServer {
             foreach ($item in $Name) {
                 $response = _InvokeNSRestApi -Session $Session -Method Get -Type server -Resource $item -Action Get 
                 if ($response.errorcode -ne 0) { throw $response }
+                if ($Response.psobject.properties.name -contains 'server') {
                     $response.server
                 }
+            }
         } else {
             $response = _InvokeNSRestApi -Session $Session -Method Get -Type server -Action Get
             if ($response.errorcode -ne 0) { throw $response }
-            $response.server
+            if ($Response.psobject.properties.name -contains 'server') {
+                $response.server
+            }
         }
     }
 }

--- a/NetScaler/Public/Get-NSLBServiceGroup.ps1
+++ b/NetScaler/Public/Get-NSLBServiceGroup.ps1
@@ -55,11 +55,15 @@ function Get-NSLBServiceGroup {
         if ($Name.Count -gt 0) {
             foreach ($item in $Name) {
                 $serviceGroups = _InvokeNSRestApi -Session $Session -Method Get -Type servicegroup -Action Get -Resource $item
-                return $serviceGroups.servicegroup
+                if ($ServiceGroups.psobject.properties.name -contains 'servicegroup') {
+                    return $serviceGroups.servicegroup
+                }
             }
         } else {
             $serviceGroups = _InvokeNSRestApi -Session $Session -Method Get -Type servicegroup -Action Get
-            return $serviceGroups.servicegroup
+            if ($ServiceGroups.psobject.properties.name -contains 'servicegroup') {
+                return $serviceGroups.servicegroup
+            }
         }
     }
 }


### PR DESCRIPTION
When no NS resources were returned, calling those `Get-*` cmdlets would throw an exception. 