### PR TITLE
Upload files to the NS appliance (certs) and a typo in Add-NSCertKeyPair

### DIFF
--- a/NetScaler/NetScaler.psd1
+++ b/NetScaler/NetScaler.psd1
@@ -68,7 +68,9 @@ PowerShellVersion = '3.0'
 # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
 FunctionsToExport = 'Add-NSCertKeyPair', 'Add-NSDnsNameServer', 'Add-NSIPResource', 
                'Add-NSLBVirtualServerBinding', 'Add-NSRSAKey', 
-               'Add-NSServerCertificate', 'Clear-NSConfig', 'Connect-NetScaler', 
+               'Add-NSServerCertificate', 
+               'Add-NSSystemFile',
+               'Clear-NSConfig', 'Connect-NetScaler', 
                'Disable-NSFeature', 'Disable-NSLBMonitor', 'Disable-NSLBServer', 
                'Disable-NSLBVirtualServer', 'Disable-NSMode', 'Disconnect-NetScaler', 
                'Enable-NSFeature', 'Enable-NSLBMonitor', 'Enable-NSLBServer', 

--- a/NetScaler/Public/Add-NSCertKeyPair.ps1
+++ b/NetScaler/Public/Add-NSCertKeyPair.ps1
@@ -95,7 +95,7 @@ function Add-NSCertKeyPair {
                 if ($CertKeyFormat -eq 'PEM' -and $Password) {
                     $bstr = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($Password)
                     $unsecurePassword = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto($bstr)
-                    $params.Add("passcrypt",$unsecurePassword)
+                    $params.Add("passplain",$unsecurePassword)
                 }
                 $response = _InvokeNSRestApi  -Session $Session -Method POST -Type sslcertkey -Payload $params -Action add 
             } catch {

--- a/NetScaler/Public/Add-NSSystemFile.ps1
+++ b/NetScaler/Public/Add-NSSystemFile.ps1
@@ -1,0 +1,88 @@
+<#
+Copyright 2016 Dominique Broeglin
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+#>
+
+function Add-NSSystemFile {
+    <#
+    .SYNOPSIS
+        Add a file on the given location on the NetScaler appliance.
+
+    .DESCRIPTION
+        Add a file on the given location on the NetScaler appliance.
+
+    .EXAMPLE
+        Add-NSSystemFile -Path '/tmp/aaa.extlab.local.pfx -FileLocation '/nsconfig/ssl' -Filename 'aaa.extlab.local.pfx'
+        
+        Adds the local '/tmp/aaa.extlab.local.pfx' to the certificate directory on the 
+        NetScaler appliance under the name 'aaa.extlab.local.pfx'
+
+    .PARAMETER Session
+        The NetScaler session object.
+
+    .PARAMETER Path
+        Local path of the file to upload to the NetScaler appliance.
+        
+    .PARAMETER FileLocation
+        Path of the directory, on the NetScaler appliance, where the file will be uploaded.
+        
+    .PARAMETER Filename
+        Name of the file once it is uploaded on the NetScaler appliance.
+
+    .PARAMETER Force
+        Suppress confirmation when creating the system file (this does not override a 
+        pre-existing file).
+        
+    .Notes
+        Nitro implementation status: partial        
+    #>
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact='Low')]
+    param(
+        $Session = $script:Session,
+       
+        [parameter(Mandatory)]
+        [String]$Path,
+ 
+        [parameter(Mandatory)]
+        [String]$FileLocation,
+ 
+        [parameter(Mandatory)]
+        [String]$Filename,
+
+        [switch]$Force
+    )
+
+    begin {
+        _AssertSessionActive
+    }
+
+    process {
+        $fileName = Split-Path -Path $Path -Leaf
+        if ($Force -or $PSCmdlet.ShouldProcess($Path, 'Add system file')) {
+            try {
+                $certContent = Get-Content -Path $Path -Encoding "Byte"
+                $certContentBase64 = [System.Convert]::ToBase64String($certContent)
+                $params = @{
+                    filename = $FileName
+                    filecontent = $certContentBase64
+                    filelocation = $FileLocation
+                    fileencoding = 'BASE64'
+                }  
+                _InvokeNSRestApi -Session $Session -Method POST -Type systemfile systemfile -Payload $params -Action add
+            } catch {
+                throw $_
+            }
+        }
+    }
+}

--- a/NetScaler/Public/New-NSLBServer.ps1
+++ b/NetScaler/Public/New-NSLBServer.ps1
@@ -52,6 +52,11 @@ function New-NSLBServer {
         Note: If you do not create a server entry, the server IP address that you enter when you create 
         a service becomes the name of the server.
 
+
+    .PARAMETER Domain
+        FQDN of the server. If you create a 'Domain Name' type of server, this parameter contains the
+        FQDN of the server associated to the NetScaler server resource.
+
     .PARAMETER Comment
         Any information about the server.
 
@@ -78,9 +83,12 @@ function New-NSLBServer {
         [parameter(Mandatory = $true)]
         [string[]]$Name = (Read-Host -Prompt 'LB server name'),
 
-        [parameter(Mandatory)]
+        [parameter(Mandatory,ParameterSetName='IPAddress')]
         [ValidateScript({$_ -match [IPAddress]$_ })]
         [string]$IPAddress,
+
+        [parameter(Mandatory,ParameterSetName='DomainName')]
+        [string]$Domain,
 
         [ValidateLength(0, 256)]
         [string]$Comment = [string]::Empty,
@@ -104,10 +112,15 @@ function New-NSLBServer {
                 try {
                     $params = @{
                         name = $item
-                        ipaddress = $IPAddress
                         comment = $Comment
                         td = $TrafficDomainId
                         state = $State
+                    }
+                    if ($PSBoundParameters.ContainsKey('IPAddress')) {
+                        $params.Add('ipaddress', $IPAddress)
+                    }
+                    if ($PSBoundParameters.ContainsKey('Domain')) {
+                        $params.Add('domain', $Domain)
                     }
                     _InvokeNSRestApi -Session $Session -Method POST -Type server -Payload $params -Action add
 


### PR DESCRIPTION
This add a partial `Add-NSSystemFile`. It is based on `Install-NSLicense` but is more generic. I needed it to upload certificates.

Also, the password type when installing a PEM type of certificate seemed to be wrong in Add-NSCertKeyPair. I changed it to `plainpass` to make it work.

Finally, the last commit adds a `-Domain` parameter to the `New-NSLBServer` cmdlet to allow creation of FQDN based servers.