### PR TITLE
Added parameter alias

### DIFF
--- a/NetScaler/Public/Get-NSLBServiceGroupMemberBinding.ps1
+++ b/NetScaler/Public/Get-NSLBServiceGroupMemberBinding.ps1
@@ -38,6 +38,7 @@ function Get-NSLBServiceGroupMemberBinding {
         $Session = $script:session,
 
         [parameter(Mandatory, ValueFromPipeline = $true, Position = 0, ValueFromPipelineByPropertyName)]
+        [alias('servicegroupname')]
         [string[]]$Name
     )
 


### PR DESCRIPTION
## Description
Added parameter alias 'servicegroupname' for the 'Name' parameter in Get-NSLBServiceGroupMemberBinding. This update allows the output of Get-NSLBServiceGroup to be directly piped to Get-NSLBServiceGroupMemberBinding by property name.

## How Has This Been Tested?
Executed 'Get-NSLBServiceGroup | Get-NSLBServiceGroupMemberBinding ' against MPX v10.5

## Types of changes
- [] Minor enhancement