### PR TITLE
Multiple Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
   * Bug fixes
     * Fixed bug in Add-NSLBVirtualServerBinding where weight was improperly being added when binding to a service group. (via @rokett)
     * Fixed Set-NSHostname and Set-NSTimeZone update actions (via @iainbrighton)
+    * Fixed ConvertTo-Json depth in PowerShell 5.1 (via @iainbrighton)
 
 ## 1.2.0 (2016-04-19)
   - Added Invoke-Nitro to wrap direct calls to _InvokeNSRestApi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
     * Added Get-NSAAAGroup (via @psminion)
     * Added Get-NSAAAGroupBinding (via @psminion)
     * Added Get-NSAAAUser (via @psminion)
-    * Added Get-NSAAAUserBinding (via @psminion)    
+    * Added Get-NSAAAUserBinding (via @psminion)
     * Added Get-NSCSVirtualServerResponderPolicyBinding (via @rokett)
     * Added Get-NSLBServiceGroupMonitorBinding (via @rokett)
     * Added Get-NSLBSSLVirtualServer (via @rokett)
@@ -22,12 +22,13 @@
 
   * Bug fixes
     * Fixed bug in Add-NSLBVirtualServerBinding where weight was improperly being added when binding to a service group. (via @rokett)
+    * Fixed Set-NSHostname and Set-NSTimeZone update actions (via @iainbrighton)
 
 ## 1.2.0 (2016-04-19)
   - Added Invoke-Nitro to wrap direct calls to _InvokeNSRestApi
   - Added Get-NSConfig : retrieve NetScaler configuration (running or saved)
   - Added Get/New/Set/Remove-NSResponderAction
-  - Modified Get-NSLBMonitor, Get-NSLBServer, Get-NSLBServiceGroup to only return 
+  - Modified Get-NSLBMonitor, Get-NSLBServer, Get-NSLBServiceGroup to only return
     resources if there are resources to return.
 
 ## 1.1.3 (2016-04-03)
@@ -42,4 +43,4 @@
   - Correct typo in Install-NSLicense
   - Correct typo in New-NSLBServiceGroup/Set-NSLBServiceGroup
   - Add -Force and -PassThru to Set-NSTimeZone
-  - Allow any filepath when installing NS license in Install-NSLicense  
+  - Allow any filepath when installing NS license in Install-NSLicense

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
     * Fixed Set-NSHostname and Set-NSTimeZone update actions (via @iainbrighton)
     * Fixed ConvertTo-Json depth in PowerShell 5.1 (via @iainbrighton)
     * Fixed filename rewrite issue in Add-NSSystemFile (via @iainbrighton)
+    * Fixed certificate import without private key in Add-NSCertKeyPair (via @iainbrighton)
 
 ## 1.2.0 (2016-04-19)
   - Added Invoke-Nitro to wrap direct calls to _InvokeNSRestApi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
     * Fixed bug in Add-NSLBVirtualServerBinding where weight was improperly being added when binding to a service group. (via @rokett)
     * Fixed Set-NSHostname and Set-NSTimeZone update actions (via @iainbrighton)
     * Fixed ConvertTo-Json depth in PowerShell 5.1 (via @iainbrighton)
+    * Fixed filename rewrite issue in Add-NSSystemFile (via @iainbrighton)
 
 ## 1.2.0 (2016-04-19)
   - Added Invoke-Nitro to wrap direct calls to _InvokeNSRestApi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
   * Improvements
     * Modified New-NSLBMonitor allow setting HTTP request and expected response codes parameters (via @rokett)
     * Modified New-NSLBVirtualServer to allow setting PersistenceType and PersistenceTimeout parameters (via @rokett)
+    * Modified New-NSLBMonitor to support custom monitor properties (via @iainbrighton)
 
   * Bug fixes
     * Fixed bug in Add-NSLBVirtualServerBinding where weight was improperly being added when binding to a service group. (via @rokett)

--- a/NetScaler/Private/_InvokeNSRestApi.ps1
+++ b/NetScaler/Private/_InvokeNSRestApi.ps1
@@ -1,9 +1,9 @@
 function _InvokeNSRestApi {
     <#
     .SYNOPSIS
-        Invoke NetScaler NITRO REST API 
+        Invoke NetScaler NITRO REST API
     .DESCRIPTION
-        Invoke NetScaler NITRO REST API 
+        Invoke NetScaler NITRO REST API
     .PARAMETER Session
         An existing custom NetScaler Web Request Session object returned by Connect-NetScaler
     .PARAMETER Method
@@ -42,7 +42,7 @@ function _InvokeNSRestApi {
         [Parameter(Mandatory)]
         [string]$Type,
 
-        [string]$Resource, 
+        [string]$Resource,
 
         [string]$Action,
 
@@ -61,13 +61,13 @@ function _InvokeNSRestApi {
         [ValidateSet('EXIT', 'CONTINUE', 'ROLLBACK')]
         [string]$OnErrorAction = 'EXIT'
     )
-    
+
     if ($Stat) {
         $uri = "$($Script:protocol)://$($Session.Endpoint)/nitro/v1/stat/$Type"
     } else {
         $uri = "$($Script:protocol)://$($Session.Endpoint)/nitro/v1/config/$Type"
     }
-    
+
     if (-not [string]::IsNullOrEmpty($Resource)) {
         $uri += "/$Resource"
     }
@@ -120,7 +120,7 @@ function _InvokeNSRestApi {
         $hashtablePayload = @{}
         $hashtablePayload.'params' = @{'warning' = $warning; 'onerror' = $OnErrorAction; <#"action"=$Action#>}
         $hashtablePayload.$Type = $Payload
-        $jsonPayload = ConvertTo-Json -InputObject $hashtablePayload -Depth ([int]::MaxValue)
+        $jsonPayload = ConvertTo-Json -InputObject $hashtablePayload -Depth 100
         Write-Verbose -Message "JSON Payload:`n$jsonPayload"
     }
 
@@ -136,13 +136,13 @@ function _InvokeNSRestApi {
             ErrorVariable = 'restError'
             Verbose = $false
         }
-        
+
         if ($Method -ne 'GET') {
             $restParams.Add('Body', $jsonPayload)
         }
 
         $response = Invoke-RestMethod @restParams
-        
+
         if ($response) {
             if ($response.severity -eq 'ERROR') {
                 throw "Error. See response: `n$($response | Format-List -Property * | Out-String)"

--- a/NetScaler/Public/Add-NSCertKeyPair.ps1
+++ b/NetScaler/Public/Add-NSCertKeyPair.ps1
@@ -23,6 +23,14 @@ function Add-NSCertKeyPair {
         Add server certificate to NetScaler appliance.
 
     .EXAMPLE
+        Add-NSCertKeyPair -CertKeyName 'myrootCA' -CertPath '/nsconfig/ssl/mycertificate.cert' -CertKeyFormat 'PEM'
+
+        Creates a root certificate key pair named 'myrootCA' using the PEM formatted certificate 'mycertificate.cert' located on the appliance.
+
+    .EXAMPLE
+        Add-NSCertKeyPair -CertKeyName 'mywildcardcert' -CertPath '/nsconfig/ssl/mywildcard.cert' -KeyPath '/nsconfig/ssl/mywildcard.key' -CertKeyFormat 'PEM'
+
+        Creates a certificate key pair named 'mywildardcert' using the PEM formatted certificate 'mywildcard.cert' and 'mywildcard.key' key file located on the appliance.
 
     .PARAMETER Session
         The NetScaler session object.
@@ -73,7 +81,7 @@ function Add-NSCertKeyPair {
         [string]$KeyPath,
 
         [Parameter()]
-        [ValidateSet('PEM','DER','PFX'')]
+        [ValidateSet('PEM','DER','PFX')]
         [string]$CertKeyFormat = 'PEM',
 
         [Parameter()]

--- a/NetScaler/Public/Add-NSCertKeyPair.ps1
+++ b/NetScaler/Public/Add-NSCertKeyPair.ps1
@@ -28,10 +28,10 @@ function Add-NSCertKeyPair {
         The NetScaler session object.
 
     .PARAMETER CertKeyName
-        Name for the certificate and private-key pair. Must begin with an ASCII alphanumeric or underscore (_) character, 
-        and must contain only ASCII alphanumeric, underscore, hash (#), period (.), space, colon (:), at (@), equals (=), 
+        Name for the certificate and private-key pair. Must begin with an ASCII alphanumeric or underscore (_) character,
+        and must contain only ASCII alphanumeric, underscore, hash (#), period (.), space, colon (:), at (@), equals (=),
         and hyphen (-) characters. Cannot be changed after the certificate-key pair is created. The following requirement
-        applies only to the NetScaler CLI: If the name includes one or more spaces, enclose the name in double or single 
+        applies only to the NetScaler CLI: If the name includes one or more spaces, enclose the name in double or single
         quotation marks (for example, "my cert" or 'my cert').
 
     .PARAMETER CertPath
@@ -43,17 +43,18 @@ function Add-NSCertKeyPair {
     .PARAMETER KeyPath
         Name of and, optionally, path to the private-key file that is used to form the certificate-key pair.
         The certificate file should be present on the appliance's hard-disk drive or solid-state drive.
-        Storing a certificate in any location other than the default might cause inconsistency in a high availability setup. 
+        Storing a certificate in any location other than the default might cause inconsistency in a high availability setup.
         '/nsconfig/ssl/' is the default path.
 
     .PARAMETER CertKeyFormat
         Input format of the certificate and the private-key files.
-        The two formats supported by the appliance are:
+        The three formats supported by the appliance are:
             PEM - Privacy Enhanced Mail
-            DER - Distinguished Encoding Rule.
-        
+            DER - Distinguished Encoding Rule
+            PFX - PKCS#12 binary format
+
         Default value: PEM
-        Possible values = DER, PEM
+        Possible values = DER, PEM, PFX
 
     .PARAMETER Password
         Passphrase that was used to encrypt the private-key. Use this option to load encrypted private-keys in PEM format.
@@ -72,8 +73,8 @@ function Add-NSCertKeyPair {
         [string]$KeyPath,
 
         [Parameter()]
-        [ValidateSet("PEM","DER")]
-        [string]$CertKeyFormat="PEM",
+        [ValidateSet('PEM','DER','PFX'')]
+        [string]$CertKeyFormat = 'PEM',
 
         [Parameter()]
         [securestring]$Password
@@ -86,18 +87,20 @@ function Add-NSCertKeyPair {
     process {
         if ($PSCmdlet.ShouldProcess($CertKeyName, 'Add SSL certificate and private key pair')) {
             try {
-                $params = @{
+                 $params = @{
                     certkey = $CertKeyName
                     cert = $CertPath
-                    key = $KeyPath
                     inform = $CertKeyFormat
                 }
-                if ($CertKeyFormat -eq 'PEM' -and $Password) {
+                if ($PSBoundParameters.ContainsKey('KeyPath')) {
+                    $params.Add('key', $KeyPath)
+                }
+                if (($CertKeyFormat -in 'PEM','PFX') -and $Password) {
                     $bstr = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($Password)
                     $unsecurePassword = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto($bstr)
                     $params.Add("passplain",$unsecurePassword)
                 }
-                $response = _InvokeNSRestApi  -Session $Session -Method POST -Type sslcertkey -Payload $params -Action add 
+                $response = _InvokeNSRestApi  -Session $Session -Method POST -Type sslcertkey -Payload $params -Action add
             } catch {
                 throw $_
             }

--- a/NetScaler/Public/Add-NSSystemFile.ps1
+++ b/NetScaler/Public/Add-NSSystemFile.ps1
@@ -24,8 +24,8 @@ function Add-NSSystemFile {
 
     .EXAMPLE
         Add-NSSystemFile -Path '/tmp/aaa.extlab.local.pfx -FileLocation '/nsconfig/ssl' -Filename 'aaa.extlab.local.pfx'
-        
-        Adds the local '/tmp/aaa.extlab.local.pfx' to the certificate directory on the 
+
+        Adds the local '/tmp/aaa.extlab.local.pfx' to the certificate directory on the
         NetScaler appliance under the name 'aaa.extlab.local.pfx'
 
     .PARAMETER Session
@@ -33,30 +33,30 @@ function Add-NSSystemFile {
 
     .PARAMETER Path
         Local path of the file to upload to the NetScaler appliance.
-        
+
     .PARAMETER FileLocation
         Path of the directory, on the NetScaler appliance, where the file will be uploaded.
-        
+
     .PARAMETER Filename
         Name of the file once it is uploaded on the NetScaler appliance.
 
     .PARAMETER Force
-        Suppress confirmation when creating the system file (this does not override a 
+        Suppress confirmation when creating the system file (this does not override a
         pre-existing file).
-        
+
     .Notes
-        Nitro implementation status: partial        
+        Nitro implementation status: partial
     #>
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact='Low')]
     param(
         $Session = $script:Session,
-       
+
         [parameter(Mandatory)]
         [String]$Path,
- 
+
         [parameter(Mandatory)]
         [String]$FileLocation,
- 
+
         [parameter(Mandatory)]
         [String]$Filename,
 
@@ -68,7 +68,7 @@ function Add-NSSystemFile {
     }
 
     process {
-        $fileName = Split-Path -Path $Path -Leaf
+        $FileName = Split-Path -Path $FileName -Leaf
         if ($Force -or $PSCmdlet.ShouldProcess($Path, 'Add system file')) {
             try {
                 $certContent = Get-Content -Path $Path -Encoding "Byte"
@@ -78,7 +78,7 @@ function Add-NSSystemFile {
                     filecontent = $certContentBase64
                     filelocation = $FileLocation
                     fileencoding = 'BASE64'
-                }  
+                }
                 _InvokeNSRestApi -Session $Session -Method POST -Type systemfile systemfile -Payload $params -Action add
             } catch {
                 throw $_

--- a/NetScaler/Public/New-NSLBMonitor.ps1
+++ b/NetScaler/Public/New-NSLBMonitor.ps1
@@ -26,16 +26,16 @@ function New-NSLBMonitor {
         The NetScaler session object.
 
     .PARAMETER Name
-        Name for the monitor. 
+        Name for the monitor.
         Must begin with an ASCII alphanumeric or underscore (_) character, and must contain
         only ASCII alphanumeric, underscore, hash (#), period (.), space, colon (:), at (@),
-        equals (=), and hyphen (-) characters. 
+        equals (=), and hyphen (-) characters.
 
         Minimum length = 1
 
     .PARAMETER Type
         Type of monitor that you want to create.
-        
+
         Possible values = PING, TCP, HTTP, TCP-ECV, HTTP-ECV, UDP-ECV, DNS, FTP, LDNS-PING,
         LDNS-TCP, LDNS-DNS, RADIUS, USER, HTTP-INLINE, SIP-UDP, LOAD, FTP-EXTENDED, SMTP,
         SNMP, NNTP, MYSQL, MYSQL-ECV, MSSQL-ECV, ORACLE-ECV, LDAP, POP3, CITRIX-XML-SERVICE,
@@ -57,13 +57,13 @@ function New-NSLBMonitor {
         Possible values = SEC, MSEC, MIN
 
     .PARAMETER DestinationIP
-        IP address of the service to which to send probes. 
-        If the parameter is set to 0, the IP address of the server to which the monitor is bound is 
+        IP address of the service to which to send probes.
+        If the parameter is set to 0, the IP address of the server to which the monitor is bound is
         considered the destination IP address.
 
     .PARAMETER DestinationPort
         TCP or UDP port to which to send the probe.
-        If the parameter is set to 0, the port number of the service to which the monitor is bound is 
+        If the parameter is set to 0, the port number of the service to which the monitor is bound is
         considered the destination port. For a monitor of type USER, however, the destination port is
         the port number that is included in the HTTP request sent to the dispatcher. Does not apply to
         monitors of type PING.
@@ -72,11 +72,11 @@ function New-NSLBMonitor {
         Amount of time for which the appliance must wait before it marks a probe as FAILED.
 
     .PARAMETER ResponseTimeoutType
-        Amount of time for which the appliance must wait before it marks a probe as FAILED. 
-        Must be less than the value specified for the Interval parameter. 
-    
-        Note: For UDP-ECV monitors for which a receive string is not configured, response timeout 
-        does not apply. For UDP-ECV monitors with no receive string, probe failure is indicated by 
+        Amount of time for which the appliance must wait before it marks a probe as FAILED.
+        Must be less than the value specified for the Interval parameter.
+
+        Note: For UDP-ECV monitors for which a receive string is not configured, response timeout
+        does not apply. For UDP-ECV monitors with no receive string, probe failure is indicated by
         an ICMP port unreachable error received from the service.
 
         Default value: 2
@@ -113,8 +113,8 @@ function New-NSLBMonitor {
     .PARAMETER ResponseTimeoutThreshold
         Response time threshold, specified as a percentage of the Response Time-out parameter.
         If the response to a monitor probe has not arrived when the threshold is reached, the appliance generates
-        an SNMP trap called monRespTimeoutAboveThresh. After the response time returns to a value below the threshold, 
-        the appliance generates a monRespTimeoutBelowThresh SNMP trap. For the traps to be generated, 
+        an SNMP trap called monRespTimeoutAboveThresh. After the response time returns to a value below the threshold,
+        the appliance generates a monRespTimeoutBelowThresh SNMP trap. For the traps to be generated,
         the "MONITOR-RTO-THRESHOLD" alarm must also be enabled.
 
         Minimum value = 0
@@ -161,8 +161,8 @@ function New-NSLBMonitor {
         Maximum value = 63
 
     .PARAMETER State
-        State of the monitor. 
-        The DISABLED setting disables not only the monitor being configured, but all monitors of the same type, until the parameter 
+        State of the monitor.
+        The DISABLED setting disables not only the monitor being configured, but all monitors of the same type, until the parameter
         is set to ENABLED. If the monitor is bound to a service, the state of the monitor is not taken into account when the state
         of the service is determined.
 
@@ -221,14 +221,19 @@ function New-NSLBMonitor {
     .PARAMETER ScriptArgs
         String of arguments for the script. The string is copied verbatim into the request.
 
-    .PARAMETER Passthru
-        Return the load balancer monitor object.
+    .PARAMETER CustomProperty
+        Send additional monitor-specific properties when creating the monitor.
+
+        Example STOREFRONT monitor value: @{ StoreName = 'Store' }
 
     .PARAMETER ResponseCode
         Response codes for which to mark the service as UP
 
     .PARAMETER HTTPRequest
         HTTP request to send to the server (for example, "HEAD /file.html").
+
+    .PARAMETER Passthru
+        Return the load balancer monitor object.
     #>
     [cmdletbinding(SupportsShouldProcess = $true, ConfirmImpact='Low')]
     param(
@@ -280,7 +285,7 @@ function New-NSLBMonitor {
         [int]$AlertRetries,
 
         [ValidateRange(0, 32)]
-        [int]$SuccessRetries = 1, 
+        [int]$SuccessRetries = 1,
 
         [ValidateRange(0, 32)]
         [int]$FailureRetries,
@@ -301,7 +306,7 @@ function New-NSLBMonitor {
         [string]$Reverse = 'NO',
 
         [ValidateSet('YES', 'NO')]
-        [string]$Transparent = 'NO', 
+        [string]$Transparent = 'NO',
 
         [ValidateSet('ENABLED', 'DISABLED')]
         [string]$LRTM = 'DISABLED',
@@ -315,11 +320,13 @@ function New-NSLBMonitor {
         [string]$ScriptName,
 
         [ValidateScript({$_ -match [IPAddress]$_ })]
-        [string]$DispatcherIP, 
+        [string]$DispatcherIP,
 
         [int]$DispatcherPort,
 
         [string]$ScriptArgs,
+
+        [System.Collections.Hashtable]$CustomProperty,
 
         [switch]$PassThru,
 
@@ -391,6 +398,12 @@ function New-NSLBMonitor {
                     }
                     if ($PSBoundParameters.ContainsKey('ScriptArgs')) {
                         $params.Add('scriptargs', $ScriptArgs)
+                    }
+                    if ($PSBoundParameters.ContainsKey('CustomProperty')) {
+                        ## Add each custom property to the $params Hashtable
+                        foreach ($key in $CustomProperty.Keys) {
+                            $params.Add($key.ToLower(), $CustomProperty[$key])
+                        }
                     }
                     if ($PSBoundParameters.ContainsKey('ResponseCode')) {
                         $params.Add('respcode', $ResponseCode)

--- a/NetScaler/Public/Set-NSHostname.ps1
+++ b/NetScaler/Public/Set-NSHostname.ps1
@@ -44,7 +44,7 @@ function Set-NSHostname {
     param(
         [parameter(Mandatory)]
         $Session = $script:session,
-        
+
         [parameter(Mandatory)]
         [ValidateLength(1, 255)]
         [string]$Hostname = (Read-Host -Prompt 'NetScaler hostname'),
@@ -64,8 +64,8 @@ function Set-NSHostname {
             $params = @{
                 hostname = $Hostname
             }
-            _InvokeNSRestApi -Session $Session -Method PUT -Type nshostname -Payload $params -Action update
-        
+            _InvokeNSRestApi -Session $Session -Method PUT -Type nshostname -Payload $params
+
             if ($PSBoundParameters.ContainsKey('PassThru')) {
                 return _InvokeNSRestApi -Session $Session -Method GET -Type nshostname -Action get
             }

--- a/NetScaler/Public/Set-NSHostname.ps1
+++ b/NetScaler/Public/Set-NSHostname.ps1
@@ -23,10 +23,14 @@ function Set-NSHostname {
         Set NetScaler hostname
 
     .EXAMPLE
-        Set-NSHostname -Session $session -HostName 'mynsappliance'
+        Set-NSHostname -Session $session -Hostname 'mynsappliance'
+
+        Changes the NetScaler hostname to 'mynsappliance'
 
     .EXAMPLE
-        Set-NSHostname -HostName 'mynsappliance'
+        Set-NSHostname -Hostname 'mynsappliance'
+
+        Changes the NetScaler hostname to 'mynsappliance'
 
     .PARAMETER Session
         The NetScaler session object.

--- a/NetScaler/Public/Set-NSTimeZone.ps1
+++ b/NetScaler/Public/Set-NSTimeZone.ps1
@@ -27,9 +27,13 @@ function Set-NSTimeZone {
     .EXAMPLE
         Set-NSTimeZone -Session $session -TimeZone 'GMT-07:00-PDT-America/Los_Angeles'
 
+        Configures the NetScaler appliance timezone to 'America/Los_Angeles'.
+
     .EXAMPLE
-        $tz = Get-NSAvailableTimeZones | Where-Object {$_ -contains 'Paris'} | Select-Object -First 1
-        Set-NSHostname -HostName 'mynsappliance' -TimeZone $tz
+        $tz = Get-NSAvailableTimeZone | Where-Object {$_ -match 'Paris'} | Select-Object -First 1
+        Set-NSTimeZone -HostName 'mynsappliance' -TimeZone $tz
+
+        Configures the NetScaler appliance timezone to and available timezone that has 'Paris' in its name.
 
     .PARAMETER Session
         The NetScaler session object.

--- a/NetScaler/Public/Set-NSTimeZone.ps1
+++ b/NetScaler/Public/Set-NSTimeZone.ps1
@@ -36,18 +36,18 @@ function Set-NSTimeZone {
 
     .PARAMETER Timezone
         The timezone to set the appliance to.
-        
+
     .PARAMETER Force
         Suppress confirmation when updating the timezone.
-        
+
     .PARAMETER Passthru
-        Return the hostname.        
+        Return the hostname.
     #>
     [cmdletbinding(SupportsShouldProcess = $true, ConfirmImpact='high')]
     param(
         [parameter(Mandatory)]
         $Session = $script:session,
-        
+
         [parameter(Mandatory)]
         [ValidateScript({
             if ($NSTimeZones -contains $_) {
@@ -59,7 +59,7 @@ function Set-NSTimeZone {
         [string]$TimeZone,
 
         [switch]$Force,
-        
+
         [switch]$PassThru
     )
 
@@ -73,7 +73,7 @@ function Set-NSTimeZone {
             $params = @{
                 timezone = $TimeZone
             }
-            _InvokeNSRestApi -Session $Session -Method PUT -Type nsconfig -Payload $params -Action update
+            _InvokeNSRestApi -Session $Session -Method PUT -Type nsconfig -Payload $params
 
             if ($PSBoundParameters.ContainsKey('PassThru')) {
                 $config = _InvokeNSRestApi -Session $Session -Method GET -Type nsconfig -Action get


### PR DESCRIPTION
## Description
* Fixed Set-NSHostname and Set-NSTimeZone update actions
 * Fixes #16
* Fixed ConvertTo-Json depth in PowerShell 5.1
 * Fixes #17 
* Fixed filename rewrite issue in Add-NSSystemFile
 * Fixes #18 
* Fixed DER certificate and certificate import without private key in Add-NSCertKeyPair 
 * Fixes #21 and #22 
* Add missing help examples

## How Has This Been Tested?
* Manually tested on NetScaler 10.5, 11.0 and 11.1

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Help tests are still failing but they now pass on:
* Add-NSCertKeyPair
* Add-NSSystemFile
* Set-NSHostName
* Set-NSTimeZone