### PR TITLE
Added 32 additional commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,28 @@
     * Added New-NSCSVirtualServer (via @rokett)
     * Added New-NSLBServiceGroupMonitor (via @rokett)
     * Added Set-NSLBSSLVirtualServer (via @rokett)
+    * Added Get-NSVersion (via @iainbrighton)
+    * Added Get-NSDnsNameServer (via @iainbrighton)
+    * Added Get-NSDnsSuffix, Add-NSDnsSuffix and Remove-NSDnsSuffix (via @iainbrighton)
+    * Added Get-NSSSLCertificateLink, Add-NSSSLCertificateLink and Remove-NSSSLCertificateLink (via @iainbrighton)
+    * Added Get-NSSSLProfile, New-NSSSLProfile, Set-NSSSLProfile and Remove-NSSSLProfile (via @iainbrighton)
+    * Added Add-NSLBServiceGroupMonitorBinding and Remove-NSLBServiceGroupMonitorBinding (via @iainbrighton)
+    * Added Get-NSLBSSLVirtualServerProfile, Set-NSLBSSLVirtualServerProfile and Remove-NSLBSSLVirtualServerProfile (via @iainbrighton)
+    * Added Get-NSLDAPAuthenticationServer, New-NSLDAPAuthenticationServer and Remove-NSLDAPAuthenticationServer (via @iainbrighton)
+    * Added Get-NSLDAPAuthenticationPolicy, New-NSLDAPAuthenticationPolicy and Remove-NSLDAPAuthenticationPolicy (via @iainbrighton
+    * Added New-NSVPNVirtualServer (via @iainbrighton)
+    * Added Get-NSVPNVirtualServerBinding and Add-NSVPNVirtualServerBinding (via @iainbrighton)
+    * Added Get-NSVPNVirtualServerTheme and Set-NSVPNVirtualServerTheme (via @iainbrighton)
+    * Added New-NSVPNSessionPolicy and Remove-NSVPNSessionPolicy (via @iainbrighton)
+    * Added New-NSVPNSessionProfile and Remove-NSVPNSessionProfile (via @iainbrighton)
 
   * Improvements
     * Modified New-NSLBMonitor allow setting HTTP request and expected response codes parameters (via @rokett)
     * Modified New-NSLBVirtualServer to allow setting PersistenceType and PersistenceTimeout parameters (via @rokett)
-    * Modified New-NSLBMonitor to support custom monitor properties (via @iainbrighton)    
+    * Modified New-NSLBMonitor to support custom monitor properties (via @iainbrighton)
+    * Modified Get-NSLBServiceGroupMonitorBinding to support filtering by monitor name (via @iainbrighton)
+    * Added -Force parameter to Add-NSLBSSLVirtualServerCertificateBinding to suppress confirmation (via @iainbrighton)
+    * Added private _AssertNSVersion to enforce particular versioned APIs, e.g. Get-NSVPNVirtualServerTheme (via @iainbrighton)
 
   * Bug fixes
     * Fixed bug in Add-NSLBVirtualServerBinding where weight was improperly being added when binding to a service group. (via @rokett)
@@ -28,6 +45,8 @@
     * Fixed filename rewrite issue in Add-NSSystemFile (via @iainbrighton)
     * Fixed certificate import without private key in Add-NSCertKeyPair (via @iainbrighton)
     * Fixed comment-based help (via @devblackops)
+    * Fixed _InvokeNSRestApiGet to filter collections (via @iainbrighton)
+    * Fixed bug in Add-NSDnsNameServer where DNSVServerName could not be blank (via @iainbrighton)
 
 ## 1.2.0 (2016-04-19)
   - Added Invoke-Nitro to wrap direct calls to _InvokeNSRestApi

--- a/NetScaler/NetScaler.psd1
+++ b/NetScaler/NetScaler.psd1
@@ -70,13 +70,17 @@ FunctionsToExport = @(
     'Add-NSCertKeyPair',
     'Add-NSCSVirtualServerResponderPolicyBinding',
     'Add-NSDnsNameServer',
+    'Add-NSDnsSuffix',
     'Add-NSIPResource',
+    'Add-NSLBServiceGroupMonitorBinding',
     'Add-NSLBSSLVirtualServerCertificateBinding',
     'Add-NSLBVirtualServerBinding',
     'Add-NSLBVirtualServerRewritePolicyBinding',
     'Add-NSRSAKey',
     'Add-NSServerCertificate',
+    'Add-NSSSLCertificateLink',
     'Add-NSSystemFile',
+    'Add-NSVPNVirtualServerBinding',
     'Clear-NSConfig',
     'Connect-NetScaler',
     'Disable-NSFeature',
@@ -101,6 +105,8 @@ FunctionsToExport = @(
     'Get-NSCSPolicy',
     'Get-NSCSVirtualServer',
     'Get-NSCSVirtualServerResponderPolicyBinding',
+    'Get-NSDnsNameServer',
+    'Get-NSDnsSuffix',
     'Get-NSFeature',
     'Get-NSHostname',
     'Get-NSIPResource',
@@ -113,10 +119,13 @@ FunctionsToExport = @(
     'Get-NSLBServiceGroupMonitorBinding',
     'Get-NSLBSSLVirtualServer',
     'Get-NSLBSSLVirtualServerCertificateBinding',
+    'Get-NSLBSSLVirtualServerProfile',
     'Get-NSLBStat',
     'Get-NSLBVirtualServer',
     'Get-NSLBVirtualServerBinding',
     'Get-NSLBVirtualServerRewritePolicyBinding',
+    'Get-NSLDAPAuthenticationPolicy',
+    'Get-NSLDAPAuthenticationServer',
     'Get-NSResponderAction',
     'Get-NSResponderPolicy',
     'Get-NSRewriteAction',
@@ -126,11 +135,16 @@ FunctionsToExport = @(
     'Get-NSSAMLAuthenticationPolicy',
     'Get-NSSAMLAuthenticationServer',
     'Get-NSSSLCertificate',
+    'Get-NSSSLCertificateLink',
+    'Get-NSSSLProfile',
     'Get-NSSystemFile',
+    'Get-NSVersion',
     'Get-NSVPNServer',
     'Get-NSVPNSessionPolicy',
     'Get-NSVPNSessionProfile',
     'Get-NSVPNVirtualServer',
+    'Get-NSVPNVirtualServerBinding',
+    'Get-NSVPNVirtualServerTheme',
     'Install-NSLicense',
     'Invoke-Nitro',
     'New-NSCSVirtualServer',
@@ -141,24 +155,42 @@ FunctionsToExport = @(
     'New-NSLBServiceGroupMember',
     'New-NSLBServiceGroupMonitor',
     'New-NSLBVirtualServer',
+    'New-NSLDAPAuthenticationPolicy',
+    'New-NSLDAPAuthenticationServer',
     'New-NSNTPServer',
     'New-NSResponderAction',
     'New-NSNTPServer',
+    'New-NSSSLProfile',
+    'New-NSVPNSessionPolicy',
+    'New-NSVPNSessionProfile',
+    'New-NSVPNVirtualServer',
+    'Remove-NSDnsSuffix',
     'Remove-NSLBMonitor',
     'Remove-NSLBServer',
     'Remove-NSLBServiceGroup',
+    'Remove-NSLBServiceGroupMonitorBinding',
     'Remove-NSLBVirtualServer',
     'Remove-NSLBVirtualServerBinding',
+    'Remove-NSLBSSLVirtualServerProfile',
+    'Remove-NSLDAPAuthenticationPolicy',
+    'Remove-NSLDAPAuthenticationServer',
     'Remove-NSResponderAction',
+    'Remove-NSSSLCertificateLink',
+    'Remove-NSSSLProfile',
+    'Remove-NSVPNSessionPolicy',
+    'Remove-NSVPNSessionProfile',
     'Restart-NetScaler',
     'Save-NSConfig',
     'Set-NSHostname',
     'Set-NSLBServer',
     'Set-NSLBServiceGroup',
     'Set-NSLBSSLVirtualServer',
+    'Set-NSLBSSLVirtualServerProfile',
     'Set-NSLBVirtualServer',
     'Set-NSResponderAction',
-    'Set-NSTimeZone'
+    'Set-NSSSLProfile',
+    'Set-NSTimeZone',
+    'Set-NSVPNVirtualServerTheme'
 )
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
@@ -200,14 +232,14 @@ PrivateData = @{
         ReleaseNotes = '- Added Invoke-Nitro to wrap direct calls to _InvokeNSRestApi
 - Added Get-NSConfig to retrieve NetScaler configuration (running or saved)
 - Added Get/New/Set/Remove-NSResponderAction
-- Modified Get-NSLBMonitor, Get-NSLBServer, Get-NSLBServiceGroup to only return 
+- Modified Get-NSLBMonitor, Get-NSLBServer, Get-NSLBServiceGroup to only return
   resources if there are resources to return.'
 
         # External dependent modules of this module
         # ExternalModuleDependencies = ''
 
     } # End of PSData hashtable
-    
+
  } # End of PrivateData hashtable
 
 # HelpInfo URI of this module

--- a/NetScaler/Private/_AssertNSVersion.ps1
+++ b/NetScaler/Private/_AssertNSVersion.ps1
@@ -1,0 +1,51 @@
+<#
+Copyright 2016 Iain Brighton
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+#>
+
+function _AssertNSVersion {
+    <#
+    .SYNOPSIS
+        Ensures that the NetScaler appliance's version meets the specified minimum version.
+
+    .DESCRIPTION
+        Ensures that the NetScaler appliance's version meets the specified minimum version.
+
+    .PARAMETER Session
+        An existing custom NetScaler Web Request Session object returned by Connect-NetScaler.
+
+    .PARAMETER MinimumVersion
+        Specifies the minimum version of NetScaler is required.
+
+    .EXAMPLE
+        _AssertNSVersion -Session $session -MinimumVersion '11.0'
+
+        Ensure that the current session is a NetScaler 11.0 or later appliance.
+    #>
+    [cmdletbinding()]
+    param (
+        $Session = $script:session,
+
+        [parameter(Mandatory, ValueFromPipeline)]
+        [System.Version]$MinimumVersion
+    )
+
+    process {
+        $nsVersion = Get-NSVersion -Session $Session
+        if ($nsVersion.Version -lt $MinimumVersion) {
+            $errorMessage = 'Netscaler version "{0}" is unsupported. Version "{1}" or later is required for this operation.'
+            throw ($errorMessage -f $nsVersion.Version, $MinimumVersion)
+        }
+    }
+}

--- a/NetScaler/Private/_InvokeNSRestApiGet.ps1
+++ b/NetScaler/Private/_InvokeNSRestApiGet.ps1
@@ -1,7 +1,7 @@
 function _InvokeNSRestApiGet {
     <#
     .SYNOPSIS
-        Invoke NetScaler NITRO REST API GET method 
+        Invoke NetScaler NITRO REST API GET method
 
     .DESCRIPTION
         Invoke NetScaler NITRO REST API GET method
@@ -14,32 +14,32 @@ function _InvokeNSRestApiGet {
 
     .PARAMETER Name
         The name or names of the NS appliance resources.
-        
+
     .PARAMETER Filters
         A Hashtable of search filter values.
-        
+
     .EXAMPLE
         TODO
-        
-    .OUTPUTS        
+
+    .OUTPUTS
         PSCustomObject that represents the JSON response content. This object can be manipulated using the ConvertTo-Json Cmdlet.
     #>
     [CmdletBinding()]
     param (
         [Parameter(Mandatory)]
         [PSObject]$Session,
-        
+
         [parameter(ValueFromPipeline = $true, Position = 0, ValueFromPipelineByPropertyName)]
         [string[]]$Name = @(),
 
         [string]$Type,
-        
+
         [Hashtable]$Filters = @{}
     )
 
     if ($Name.Count -gt 0) {
         foreach ($item in $Name) {
-            $response = _InvokeNSRestApi -Session $Session -Method Get -Type $Type -Resource $item -Action Get 
+            $response = _InvokeNSRestApi -Session $Session -Method Get -Type $Type -Resource $item -Action Get -Filters $Filters
             if ($response.errorcode -ne 0) { throw $response }
             if ($Response.psobject.properties.name -contains $Type) {
                 $response.$Type

--- a/NetScaler/Public/Add-NSDnsNameServer.ps1
+++ b/NetScaler/Public/Add-NSDnsNameServer.ps1
@@ -58,6 +58,12 @@ function Add-NSDnsNameServer {
 
         Default value: UDP
         Possible values = UDP, TCP, UDP_TCP
+
+    .PARAMETER Passthru
+        Return the load balancer server object.
+
+    .PARAMETER Force
+        Suppress confirmation adding certificate binding
     #>
     [cmdletbinding(SupportsShouldProcess = $true, ConfirmImpact='Low')]
     param(
@@ -86,14 +92,19 @@ function Add-NSDnsNameServer {
         foreach ($item in $IPAddress) {
             if ($PSCmdlet.ShouldProcess($item, 'Add DNS server IP')) {
                 try {
+
                     $params = @{
                         ip = $IPAddress
-                        dnsvservername = $DNSVServerName
-                        local = $Local
+                        local = $Local.ToBool()
                         state = $State
                         type = $Type
                     }
+                    if ($PSBoundParameters.ContainsKey('DNSVServerName')) {
+                        $params.Add('dnsvservername', $DNSVServerName)
+                    }
+
                     $response = _InvokeNSRestApi -Session $Session -Method POST -Type dnsnameserver -Payload $params -Action add
+
                 } catch {
                     throw $_
                 }

--- a/NetScaler/Public/Add-NSDnsSuffix.ps1
+++ b/NetScaler/Public/Add-NSDnsSuffix.ps1
@@ -1,0 +1,73 @@
+<#
+Copyright 2016 Iain Brighton
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+#>
+
+function Add-NSDnsSuffix {
+    <#
+    .SYNOPSIS
+        Add domain name suffix to NetScaler appliance.
+
+    .DESCRIPTION
+        Add domain name suffix to NetScaler appliance.
+
+    .EXAMPLE
+        Add-NSDnsSuffix -DNSSuffix 'lab.local'
+
+        Adds the 'lab.local' DNS suffix to the NetScaler appliance.
+
+    .EXAMPLE
+        'lab.local', 'lab.internal' | Add-NSDnsSuffix -Session $session
+
+        Adds the 'lab.local' and 'lab.internal' DNS suffixes to the NetScaler appliance.
+
+    .PARAMETER Session
+        The NetScaler session object.
+
+    .PARAMETER Suffix
+        DNS search suffix to be appended when resolving domain names that are not fully qualified.
+
+    .PARAMETER Force
+        Suppress confirmation when adding a DNS suffix.
+    #>
+    [cmdletbinding(SupportsShouldProcess = $true, ConfirmImpact = 'Low')]
+    param (
+        $Session = $script:session,
+
+        [parameter(Mandatory, ValueFromPipeline)]
+        [string[]]$Suffix,
+
+        [Switch]$Force
+    )
+
+    begin {
+        _AssertSessionActive
+    }
+
+    process {
+        foreach ($item in $Suffix) {
+            if ($PSCmdlet.ShouldProcess($item, 'Add DNS suffix')) {
+                try {
+                    $params = @{
+                         dnssuffix = $item;
+                    }
+                    $response = _InvokeNSRestApi -Session $Session -Method POST -Type dnssuffix -Payload $params -Action add
+                }
+                catch {
+                    throw $_
+                }
+            }
+        }
+    }
+}

--- a/NetScaler/Public/Add-NSLBSSLVirtualServerCertificateBinding.ps1
+++ b/NetScaler/Public/Add-NSLBSSLVirtualServerCertificateBinding.ps1
@@ -38,6 +38,9 @@ function Add-NSLBSSLVirtualServerCertificateBinding {
 
     .PARAMETER Passthru
         Return the load balancer server object.
+
+    .PARAMETER Force
+        Suppress confirmation adding certificate binding.
     #>
     [cmdletbinding(SupportsShouldProcess = $true, ConfirmImpact='Medium', DefaultParameterSetName='servicegroup')]
     param(
@@ -49,7 +52,9 @@ function Add-NSLBSSLVirtualServerCertificateBinding {
         [parameter(Mandatory=$True)]
         [string]$Certificate,
 
-        [Switch]$PassThru
+        [Switch]$PassThru,
+
+        [switch]$Force
     )
 
     begin {
@@ -57,7 +62,7 @@ function Add-NSLBSSLVirtualServerCertificateBinding {
     }
 
     process {
-        if ($PSCmdlet.ShouldProcess($VirtualServerName, 'Add Virtual Server Binding')) {
+        if ($Force -or $PSCmdlet.ShouldProcess($VirtualServerName, 'Add Virtual Server Binding')) {
             try {
 
                 $params = @{

--- a/NetScaler/Public/Add-NSLBServiceGroupMonitorBinding.ps1
+++ b/NetScaler/Public/Add-NSLBServiceGroupMonitorBinding.ps1
@@ -1,0 +1,118 @@
+<#
+Copyright 2016 Iain Brighton
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+#>
+
+function Add-NSLBServiceGroupMonitorBinding {
+     <#
+    .SYNOPSIS
+        Adds a new service group monitor binding.
+
+    .DESCRIPTION
+        Adds a new service group monitor binding.
+
+    .EXAMPLE
+        Add-NSLBServiceGroupMonitorBinding -ServiceGroupName 'sg01' -MonitorName 'mon01'
+
+        Bind the monitor 'mon01' to service group 'sg01'.
+
+    .EXAMPLE
+        Add-NSLBServiceGroupMonitorBinding -ServiceGroupName 'sg01' -MonitorName 'mon01' -Force -PassThru
+
+        Bind the monitor 'mon01' to service group 'sg01'', suppress the confirmation and return the result.
+
+    .PARAMETER Session
+        The NetScaler session object.
+
+    .PARAMETER ServiceGroupName
+        Name of the service group to bind the monitor to.
+
+    .PARAMETER MonitorName
+        Name of the monitor to bind to the service group.
+
+    .PARAMETER Port
+        Port number of the service. Each service must have a unique port number.
+
+        Range: 1 - 65535
+
+    .PARAMETER State
+        Initial state of the service after binding.
+
+        Default value: ENABLED
+        Possible values: ENABLED, DISABLED
+
+    .PARAMETER Weight
+        Weight to assign to the servers in the service group. Specifies the capacity of the servers relative to the other servers in the load balancing configuration. The higher the weight, the higher the percentage of requests sent to the service.
+
+        Range: 1 - 100
+
+    .PARAMETER Force
+        Suppress confirmation when binding the certificate key to the virtual server.
+
+    .PARAMETER Passthru
+        Return the load balancer server object.
+    #>
+    [cmdletbinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
+    param(
+        $Session = $script:session,
+
+        [parameter(Mandatory)]
+        [string]$ServiceGroupName,
+
+        [parameter(Mandatory)]
+        [string]$MonitorName,
+
+        [ValidateSet('ENABLED','DISABLED')]
+        [string]$State = 'ENABLED',
+
+        [ValidateRange(1,100)]
+        [int]$Weight,
+
+        [ValidateRange(1,65535)]
+        [int]$Port,
+
+        [Switch]$Force,
+
+        [Switch]$PassThru
+    )
+
+    begin {
+        _AssertSessionActive
+    }
+
+    process {
+        if ($Force -or $PSCmdlet.ShouldProcess($ServiceGroupName, 'Add Monitor Binding')) {
+            try {
+                $params = @{
+                    servicegroupname = $ServiceGroupName
+                    monitor_name = $MonitorName
+                }
+                if ($PSBoundParameters.ContainsKey('Weight')) {
+                    $params.Add('weight', $Weight)
+                }
+                if ($PSBoundParameters.ContainsKey('Port')) {
+                    $params.Add('port', $Port)
+                }
+
+                _InvokeNSRestApi -Session $Session -Method PUT -Type servicegroup_lbmonitor_binding -Payload $params
+
+                if ($PSBoundParameters.ContainsKey('PassThru')) {
+                    return Get-NSLBServiceGroupMonitorBinding -Session $Session -Name $ServiceGroupName
+                }
+            } catch {
+                throw $_
+            }
+        }
+    }
+}

--- a/NetScaler/Public/Add-NSSSLCertificateLink.ps1
+++ b/NetScaler/Public/Add-NSSSLCertificateLink.ps1
@@ -1,0 +1,68 @@
+<#
+Copyright 2016 Iain Brighton
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+#>
+
+function Add-NSSSLCertificateLink {
+    <#
+    .SYNOPSIS
+        Add a SSL certificate link to an intermediate certificate.
+
+    .DESCRIPTION
+        Add a SSL certificate link to an intermediate certificate.
+
+    .EXAMPLE
+        Add-NSSSLCertificateLink -CertKeyName 'mycert' -IntermediateCertKeyName 'myCAcert'
+
+        Links the 'mycert' certificate key pair to the issuing 'myCAcert' issuing root certificate key pair.
+
+    .PARAMETER Session
+        The NetScaler session object.
+
+    .PARAMETER CertKeyName
+        Name of the certificate key pair to add the link to.
+
+    .PARAMETER IntermediateCertKeyName
+        The certificate key pair name of the intermediate certificate/CA to link.
+    #>
+    [cmdletbinding(SupportsShouldProcess = $true, ConfirmImpact='Low')]
+    param(
+        $Session = $script:session,
+
+        [Parameter(Mandatory)]
+        [string]$CertKeyName,
+
+        [Parameter(Mandatory)]
+        [string]$IntermediateCertKeyName
+    )
+
+    begin {
+        _AssertSessionActive
+    }
+
+    process {
+        if ($PSCmdlet.ShouldProcess($CertKeyName, 'Add SSL certificate link')) {
+            try {
+                 $params = @{
+                    certkey = $CertKeyName
+                    linkcertkeyname = $IntermediateCertKeyName
+                }
+                $response = _InvokeNSRestApi -Session $Session -Method POST -Type sslcertkey -Payload $params -Action link
+            }
+            catch {
+                throw $_
+            }
+        }
+    }
+}

--- a/NetScaler/Public/Add-NSVPNVirtualServerBinding.ps1
+++ b/NetScaler/Public/Add-NSVPNVirtualServerBinding.ps1
@@ -1,0 +1,148 @@
+<#
+Copyright 2016 Iain Brighton
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+#>
+
+function Add-NSVPNVirtualServerBinding {
+     <#
+    .SYNOPSIS
+        Adds a NetScaler Gateway virtual server binding.
+
+    .DESCRIPTION
+        Adds a NetScaler Gateway virtual server binding.
+
+    .EXAMPLE
+        Add-NSVPNVirtualServerBinding -Name 'ag01' -LDAPAuthenticationPolicyName 'policy_ldap01'
+
+        Bind the LDAP authentication policy named 'policy_ldap01' to the NetScaler Gateway virtual server 'ag01'.
+
+    .EXAMPLE
+        Add-NSVPNVirtualServerBinding -Name 'ag01' -SessionPolicyName 'policy_receiver'
+
+        Bind the session named 'policy_receiver' to the NetScaler Gateway virtual server 'ag01'.
+
+    .EXAMPLE
+        Add-NSVPNVirtualServerBinding -Name 'ag01' -STAServer 'https://xddc1.lab.local'
+
+        Bind the STA server 'https://xddc1.lab.local' to the NetScaler Gateway virtual server 'ag01'.
+
+    .PARAMETER Session
+        The NetScaler session object.
+
+    .PARAMETER Name
+        Name for the virtual server. Must begin with an ASCII alphanumeric or underscore (_) character, and must contain
+        only ASCII alphanumeric, underscore, hash (#), period (.), space, colon (:), at sign (@), equal sign (=),
+        and hyphen (-) characters. Can be changed after the virtual server is created.
+
+        Minimum length = 1
+
+    .PARAMETER LDAPAuthenticationPolicyName
+        The LDAP authentication policy name to bind to the NetScaler Gateway virtual server.
+
+    .PARAMETER SessionPolicyName
+        The LDAP authentication policy name to bind to the NetScaler Gateway virtual server.
+
+    .PARAMETER STAServer
+        The Secure Ticketing Authority URL to bind to the NetScaler Gateway virtual server.
+
+    .PARAMETER Priority
+        The priority, if any, of the VPN virtual server policy.
+
+    .PARAMETER Secondary
+        Bind the authentication policy as the secondary policy to use in a two-factor configuration. A user must then
+        authenticate not only to a primary authentication server but also to a secondary authentication server. User
+        groups are aggregated across both authentication servers. The user name must be exactly the same on
+        both authentication servers, but the authentication servers can require different passwords.
+
+    .PARAMETER Force
+        Suppress confirmation when binding the service group to the virtual server.
+
+    .PARAMETER Passthru
+        Return the load balancer server object.
+    #>
+    [cmdletbinding(SupportsShouldProcess = $true, ConfirmImpact='Medium', DefaultParameterSetName = 'sessionpolicy')]
+    param(
+        $Session = $script:session,
+
+        [parameter(Mandatory)]
+        [alias('VirtualServerName')]
+        [string]$Name,
+
+        [parameter(Mandatory, ParameterSetName='ldapauthenticationpolicy')]
+        [string]$LDAPAuthenticationPolicyName,
+
+        [parameter(Mandatory, ParameterSetName='sessionpolicy')]
+        [string]$SessionPolicyName,
+
+        [parameter(Mandatory, ParameterSetName='staserver')]
+        [string]$STAServer,
+
+        [parameter(ParameterSetName='ldapauthenticationpolicy')]
+        [parameter(ParameterSetName='sessionpolicy')]
+        [ValidateRange(1, 1000)]
+        [int]$Priority,
+
+        [parameter(ParameterSetName='ldapauthenticationpolicy')]
+        [parameter(ParameterSetName='sessionpolicy')]
+        [Switch]$Secondary,
+
+        [Switch]$Force,
+
+        [Switch]$PassThru
+    )
+
+    begin {
+        _AssertSessionActive
+    }
+
+    process {
+        if ($Force -or $PSCmdlet.ShouldProcess($Name, 'Add NetScaler Gateway Virtual Server Binding')) {
+            try {
+                $params = @{
+                    name = $Name
+                }
+                if ($PSBoundParameters.ContainsKey('Secondary')) {
+                    $params.Add('secondary', $Secondary.ToBool())
+                }
+                if ($PSBoundParameters.ContainsKey('Priority')) {
+                    $params.Add('priority', $Priority)
+                }
+                if ($PSBoundParameters.ContainsKey('LDAPAuthenticationPolicyName')) {
+                    $params.Add('policy', $LDAPAuthenticationPolicyName)
+                    _InvokeNSRestApi -Session $Session -Method PUT -Type vpnvserver_authenticationldappolicy_binding -Payload $params
+                    if ($PSBoundParameters.ContainsKey('PassThru')) {
+                        return Get-NSVPNVirtualServerBinding -Session $Session -Name $Name -Binding LDAPAuthenticationPolicy -PolicyName $LDAPAuthenticationPolicyName
+                    }
+                }
+                elseif ($PSBoundParameters.ContainsKey('SessionPolicyName')) {
+                    $params.Add('policy', $SessionPolicyName)
+                    _InvokeNSRestApi -Session $Session -Method PUT -Type vpnvserver_vpnsessionpolicy_binding -Payload $params
+                    if ($PSBoundParameters.ContainsKey('PassThru')) {
+                        return Get-NSVPNVirtualServerBinding -Session $Session -Name $Name -Binding SessionPolicy -PolicyName $SessionPolicyName
+                    }
+                }
+                elseif ($PSBoundParameters.ContainsKey('STAServer')) {
+                    $params.Add('staserver', $STAServer)
+                    _InvokeNSRestApi -Session $Session -Method PUT -Type vpnvserver_staserver_binding -Payload $params
+                    if ($PSBoundParameters.ContainsKey('PassThru')) {
+                        return Get-NSVPNVirtualServerBinding -Session $Session -Name $Name -Binding STAServer -PolicyName $SessionPolicyName
+                    }
+                }
+            }
+            catch {
+                throw $_
+            }
+        }
+    }
+}

--- a/NetScaler/Public/Get-NSDnsNameServer.ps1
+++ b/NetScaler/Public/Get-NSDnsNameServer.ps1
@@ -1,5 +1,5 @@
 <#
-Copyright 2015 Brandon Olin
+Copyright 2016 Iain Brighton
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,37 +14,40 @@ See the License for the specific language governing permissions and
 limitations under the License.
 #>
 
-function Get-NSLBServiceGroupMonitorBinding {
+function Get-NSDnsNameServer {
     <#
     .SYNOPSIS
-        Gets the service group binding for a service group.
+        Gets the specified DNS name server object.
 
     .DESCRIPTION
-        Gets the service group binding for a service group.
+        Gets the specified DNS name server object.
 
     .EXAMPLE
-        Get-NSLBServiceGroupMonitorBinding -Name $sg
+        Get-NSDnsNameServer
 
-        Gets the service group bindings for the 'sg' service group.
+        Get all DNS name server objects.
+
+    .EXAMPLE
+        Get-NSDnsNameServer -IPAddress '192.168.0.10'
+
+        Get the DNS name server object with the IP address of '192.168.0.10'.
 
     .PARAMETER Session
         The NetScaler session object.
 
-    .PARAMETER Name
-        The name or names of the service group to get the service group member binding for.
+    .PARAMETER IPAddress
+        A filter to apply to the IPv4 address value.
 
-    .PARAMETER MonitorName
-        Filters the returned monitors to only include the name specified
+    .PARAMETER DNSVServerName
+        A filter to apply to the DNSVServerName value.
     #>
     [cmdletbinding()]
     param(
         $Session = $script:session,
 
-        [parameter(Mandatory, ValueFromPipeline = $true, Position = 0, ValueFromPipelineByPropertyName)]
-        [string[]]$Name,
+        [string]$IPAddress,
 
-        [parameter()]
-        [string]$MonitorName
+        [string]$DNSVServerName
     )
 
     begin {
@@ -55,10 +58,13 @@ function Get-NSLBServiceGroupMonitorBinding {
         try {
             # Contruct a filter hash if we specified any filters
             $Filters = @{}
-            if ($PSBoundParameters.ContainsKey('MonitorName')) {
-                $Filters['monitor_name'] = $MonitorName
+            if ($PSBoundParameters.ContainsKey('IPAddress')) {
+                $Filters['ip'] = $IPAddress
             }
-            _InvokeNSRestApiGet -Session $Session -Type servicegroup_lbmonitor_binding -Name $Name -Filters $Filters
+            if ($PSBoundParameters.ContainsKey('DNSVServerName')) {
+                $Filters['dnsvservername'] = $DNSVServerName
+            }
+            _InvokeNSRestApiGet -Session $Session -Type dnsnameserver -Filters $Filters
         }
         catch {
             throw $_

--- a/NetScaler/Public/Get-NSDnsSuffix.ps1
+++ b/NetScaler/Public/Get-NSDnsSuffix.ps1
@@ -1,0 +1,76 @@
+<#
+Copyright 2016 Iain Brighton
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+#>
+
+function Get-NSDnsSuffix {
+    <#
+    .SYNOPSIS
+        Gets the specified DNS suffix object.
+
+    .DESCRIPTION
+        Gets the specified DNS suffix object.
+
+    .EXAMPLE
+        Get-NSDnsSuffix
+
+        Get all DNS suffix objects.
+
+    .EXAMPLE
+        Get-NSDnsSuffix -Suffix 'lab.local'
+
+        Get the DNS suffix object named 'lab.local'.
+
+    .PARAMETER Session
+        The NetScaler session object.
+
+    .PARAMETER Suffix
+        The name or names of the DNS suffixes to get.
+    #>
+    [cmdletbinding()]
+    param(
+        $Session = $script:session,
+
+        [parameter(ValueFromPipeline = $true, Position = 0, ValueFromPipelineByPropertyName)]
+        [string[]]$Suffix = @()
+    )
+
+    begin {
+        _AssertSessionActive
+        $response = @()
+    }
+
+    process {
+        try {
+            if ($Suffix.Count -gt 0) {
+                foreach ($item in $Suffix) {
+                    $response = _InvokeNSRestApi -Session $Session -Method Get -Type dnssuffix -Resource $item -Action Get
+                    if ($response.errorcode -ne 0) { throw $response }
+                    if ($Response.psobject.properties.name -contains 'dnssuffix') {
+                        $response.dnssuffix
+                    }
+                }
+            } else {
+                $response = _InvokeNSRestApi -Session $Session -Method Get -Type dnssuffix -Action Get
+                if ($response.errorcode -ne 0) { throw $response }
+                if ($Response.psobject.properties.name -contains 'dnssuffix') {
+                    $response.dnssuffix
+                }
+            }
+        }
+        catch {
+            throw $_
+        }
+    }
+}

--- a/NetScaler/Public/Get-NSLDAPAuthenticationPolicy.ps1
+++ b/NetScaler/Public/Get-NSLDAPAuthenticationPolicy.ps1
@@ -1,0 +1,56 @@
+<#
+Copyright 2016 Iain Brighton
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+#>
+
+function Get-NSLDAPAuthenticationPolicy {
+    <#
+    .SYNOPSIS
+        Gets the specified LDAP authentication policy object(s).
+
+    .DESCRIPTION
+        Gets the specified LDAP authentication policy object(s).
+
+    .PARAMETER Session
+        The NetScaler session object.
+
+    .PARAMETER Name
+        The name or names of the LDAP authentication policy object(s) to return.
+
+    .EXAMPLE
+        Get-NSLDAPAuthenticationPolicy
+
+        Get all LDAP authentication server objects.
+
+    .EXAMPLE
+        Get-NSLDAPAuthenticationPolicy -Name 'foobar'
+
+        Get the LDAP authentication policy named 'foobar'.
+    #>
+    [cmdletbinding()]
+    param(
+        $Session = $Script:Session,
+
+        [Parameter(Position = 0)]
+        [string[]]$Name = @()
+    )
+
+    begin {
+        _AssertSessionActive
+    }
+
+    process {
+        _InvokeNSRestApiGet -Session $Session -Type authenticationldappolicy -Name $Name
+    }
+}

--- a/NetScaler/Public/Get-NSLDAPAuthenticationServer.ps1
+++ b/NetScaler/Public/Get-NSLDAPAuthenticationServer.ps1
@@ -1,0 +1,57 @@
+<#
+Copyright 2016 Iain Brighton
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+#>
+
+function Get-NSLDAPAuthenticationServer {
+    <#
+    .SYNOPSIS
+        Gets the specified LDAP authentication server object(s).
+
+    .DESCRIPTION
+        Gets the specified LDAP authentication server object(s).
+
+    .PARAMETER Session
+        The NetScaler session object.
+
+    .PARAMETER Name
+        The name or names of the LDAP authentication servers object(s) to get.
+
+    .EXAMPLE
+        Get-NSLDAPAuthenticationServer
+
+        Get all LDAP authentication server objects.
+
+    .EXAMPLE
+        Get-NSLDAPAuthenticationServer -Name 'foobar'
+
+        Get the LDAP authentication server named 'foobar'.
+    #>
+    [CmdletBinding()]
+    param(
+        $Session = $Script:Session,
+
+        [Parameter(Position = 0)]
+        [string[]]$Name = @()
+    )
+
+    begin {
+        _AssertSessionActive
+    }
+
+    process {
+        _InvokeNSRestApiGet -Session $Session -Type authenticationldapaction -Name $Name
+    }
+}
+

--- a/NetScaler/Public/Get-NSSSLBVirtualServerProfile.ps1
+++ b/NetScaler/Public/Get-NSSSLBVirtualServerProfile.ps1
@@ -1,0 +1,62 @@
+<#
+Copyright 2016 Iain Brighton
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+#>
+
+function Get-NSLBSSLVirtualServerProfile {
+    <#
+    .SYNOPSIS
+        Gets the specified load balancing virtual server SSL profile object.
+
+    .DESCRIPTION
+        Gets the specified load balancing virtual server SSL profile object.
+
+    .EXAMPLE
+        Get-NSLBSSLVirtualServerProfile
+
+        Get SSL profiles assigned to all load balancer virtual server objects.
+
+    .EXAMPLE
+        Get-NSLBSSLVirtualServerProfile -Name 'vserver01'
+
+        Get the SSL profile assigned to the load balancer virtual server  'vserver01'.
+
+    .PARAMETER Session
+        The NetScaler session object.
+
+    .PARAMETER Name
+        The name or names of the load balancer virtual server to get.
+    #>
+    [cmdletbinding()]
+    param(
+        $Session = $script:session,
+
+        [Parameter(Position = 0)]
+        [alias('VirtualServerName')]
+        [string[]]$Name = @()
+    )
+
+    begin {
+        _AssertSessionActive
+    }
+
+    process {
+        try {
+            _InvokeNSRestApiGet -Session $Session -Type sslvserver -Name $Name
+        }
+        catch {
+            throw $_
+        }
+    }
+}

--- a/NetScaler/Public/Get-NSSSLCertificateLink.ps1
+++ b/NetScaler/Public/Get-NSSSLCertificateLink.ps1
@@ -1,0 +1,65 @@
+<#
+Copyright 2016 Iain Brighton
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+#>
+
+function Get-NSSSLCertificateLink {
+    <#
+    .SYNOPSIS
+        Get a SSL certificate link.
+
+    .DESCRIPTION
+        Get a SSL certificate link.
+
+    .EXAMPLE
+        Get-NSSSLCertificateLink
+
+        Get all SSL certificate links
+
+    .EXAMPLE
+        Get-NSSSLCertificateLink -Name 'mycertkey'
+
+        Get linked certificates for the SSL certificate key pair 'mycertkey'
+
+    .PARAMETER Session
+        The NetScaler session object.
+
+    .PARAMETER CertKeyName
+        Name of the certificate key pair to add the link to.
+    #>
+    [cmdletbinding()]
+    param(
+        $Session = $script:session,
+
+        [Parameter()]
+        [string]$CertKeyName
+    )
+
+    begin {
+        _AssertSessionActive
+    }
+
+    process {
+        try {
+            $Filters = @{ }
+            if ($PSBoundParameters.ContainsKey('CertKeyName')) {
+                $Filters.Add('certkeyname', $CertKeyName)
+            }
+            _InvokeNSRestApiGet -Session $Session -Type sslcertlink -Filters $Filters
+        }
+        catch {
+            throw $_
+        }
+    }
+}

--- a/NetScaler/Public/Get-NSSSLProfile.ps1
+++ b/NetScaler/Public/Get-NSSSLProfile.ps1
@@ -1,0 +1,61 @@
+<#
+Copyright 2016 Iain Brighton
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+#>
+
+function Get-NSSSLProfile {
+    <#
+    .SYNOPSIS
+        Gets the specified SSL profile object.
+
+    .DESCRIPTION
+        Gets the specified SSL profile object.
+
+    .PARAMETER Session
+        The NetScaler session object.
+
+    .PARAMETER Name
+        The name or names of the SSL profiles to get.
+
+    .EXAMPLE
+        Get-NSSSLProfile
+
+        Get all SSL profile objects.
+
+    .EXAMPLE
+        Get-NSSSLProfile -Name 'ns_default_ssl_profile_frontend'
+
+        Get the SSL profile named 'ns_default_ssl_profile_frontend'.
+    #>
+    [cmdletbinding()]
+    param(
+        $Session = $Script:Session,
+
+        [Parameter(Position=0)]
+        [string[]]$Name = @()
+    )
+
+    begin {
+        _AssertSessionActive
+    }
+
+    process {
+        try {
+            _InvokeNSRestApiGet -Session $Session -Type sslprofile -Name $Name
+        }
+        catch {
+            throw $_
+        }
+    }
+}

--- a/NetScaler/Public/Get-NSVPNVirtualServerBinding.ps1
+++ b/NetScaler/Public/Get-NSVPNVirtualServerBinding.ps1
@@ -1,0 +1,89 @@
+<#
+Copyright 2016 Iain Brighton
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+#>
+
+function Get-NSVPNVirtualServerBinding {
+    <#
+    .SYNOPSIS
+        Gets the specified NetScaler Gateway virtual server binding object.
+
+    .DESCRIPTION
+        Gets the specified NetScaler Gateway virtual server binding object.
+
+    .EXAMPLE
+        Get-NSVPNVirtualServerBinding -Name 'ag01' -Binding SessionPolicy
+
+        Get all bound session policies from the 'ag01' NetScaler Gateway virtual server object.
+
+    .EXAMPLE
+        Get-NSVPNVirtualServerBinding -Name 'ag01' -Binding LDAPAuthenticationPolicy -PolicyName 'policy_ldap1'
+
+        Get LDAP authentication policy named 'policy_ldap1' bound to the 'ag01' NetScaler Gateway virtual server object.
+
+    .PARAMETER Session
+        The NetScaler session object.
+
+    .PARAMETER Name
+        The name or names of the NetScaler Gateway virtual server to retrieve the bindings.
+
+    .PARAMETER binding
+        Type of policy binding to query.
+
+        Possible values: SessionPolicy, LDAPAuthenticationPolicy, STAServer
+
+    .PARAMETER PolicyName
+        Name of the bound policy (or STA server) to retrieve from the NetScaler Gateway virtual server.
+    #>
+    [cmdletbinding()]
+    param(
+        $Session = $script:session,
+
+        [parameter(Mandatory)]
+        [ValidateSet('SessionPolicy','LDAPAuthenticationPolicy','STAServer')]
+        [string]$Binding,
+
+        [parameter(Mandatory)]
+        [string[]]$Name,
+
+        [string]$PolicyName
+    )
+
+    process {
+        try {
+            switch ($Binding) {
+                'SessionPolicy' { $policyType = 'vpnvserver_vpnsessionpolicy_binding' }
+                'LDAPAuthenticationPolicy' { $policyType = 'vpnvserver_authenticationldappolicy_binding' }
+                'STAServer' { $policyType = 'vpnvserver_staserver_binding' }
+            }
+
+            $filters = @{}
+
+            if ($PSBoundParameters.ContainsKey('PolicyName')) {
+                if ($Binding -eq 'STAServer') {
+                    ## STA servers are not policies and are filtered based upon name
+                    $filters.Add('staserver', $PolicyName)
+                }
+                else {
+                    $filters.Add('policy', $PolicyName)
+                }
+            }
+
+            _InvokeNSRestApiGet -Session $Session -Type $policyType -Name $Name -Filters $filters
+        }
+        catch {
+            throw $_
+        }
+    }
+}

--- a/NetScaler/Public/Get-NSVPNVirtualServerTheme.ps1
+++ b/NetScaler/Public/Get-NSVPNVirtualServerTheme.ps1
@@ -1,0 +1,66 @@
+<#
+Copyright 2016 Iain Brighton
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+#>
+
+function Get-NSVPNVirtualServerTheme {
+    <#
+    .SYNOPSIS
+        Configures an existing NetScaler virtual server theme.
+
+    .DESCRIPTION
+        Configures an existing NetScaler virtual server theme.
+
+    .EXAMPLE
+        Get-NSVPNVirtualServerTheme -Name 'ag01'
+
+        Returns the NetScaler Gateway virtual server theme assigned to the 'ag01' virtual server.
+
+    .PARAMETER Session
+        The NetScaler session object.
+
+    .PARAMETER Name
+        The name or names of the NetScaler Gateway virtual servers to set.
+
+    .NOTES
+        Requires NetScaler 11.0 or later
+    #>
+    [cmdletbinding()]
+    param(
+        $Session = $script:session,
+
+        [parameter(ValueFromPipeline, ValueFromPipelineByPropertyName)]
+        [alias('VirtualServerName')]
+        [string[]]$Name
+    )
+
+    begin {
+        _AssertSessionActive
+        _AssertNSVersion -MinimumVersion '11.0'
+    }
+
+    process {
+        try {
+            if (-not $PSBoundParameters.ContainsKey('Name')) {
+                $Name = Get-NSVPNVirtualServer | Select-Object -ExpandProperty Name
+            }
+            foreach ($item in $Name) {
+                _InvokeNSRestApiGet -Session $Session -Type vpnvserver_vpnportaltheme_binding -Name $item
+            }
+        }
+        catch {
+            throw $_
+        }
+    }
+}

--- a/NetScaler/Public/Get-NSVersion.ps1
+++ b/NetScaler/Public/Get-NSVersion.ps1
@@ -1,0 +1,67 @@
+<#
+Copyright 2016 Iain Brighton
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+#>
+
+function Get-NSVersion {
+    <#
+    .SYNOPSIS
+        Gets the version information for the NetScaler appliance.
+
+    .DESCRIPTION
+        Gets the version information for the NetScaler appliance.
+
+    .EXAMPLE
+        Get-NSVersion
+
+        Get the NetScaler version information.
+
+    .PARAMETER Session
+        The NetScaler session object.
+
+    #>
+    [cmdletbinding()]
+    param(
+        $Session = $script:session
+    )
+
+    begin {
+        _AssertSessionActive
+    }
+
+    process {
+        try {
+            $response = _InvokeNSRestApi -Session $Session -Method Get -Type nsversion
+            if ($response.nsversion.version -match 'NetScaler NS\d+\.\d+:\s?Build\s\d+.\d+') {
+                if ($response.nsversion.version -match '(?<=^NetScaler NS)\d+\.\d+(?=:)') {
+                    $versionString = $Matches[0]
+                    $major = $versionString.Split('.')[0]
+                    $minor = $versionString.Split('.')[1]
+                }
+                if ($response.nsversion.version -match '(?<=Build\s)\S+(?=\,)') {
+                    $buildString = $Matches[0]
+                }
+                return [PSCustomObject] @{
+                    DisplayName = $response.nsversion.version.Split(',')[0]
+                    Version = New-Object System.Version -ArgumentList @($major, $minor)
+                    Build = $buildString
+                    KernelMode = $response.nsversion.mode -as [System.Int32]
+                }
+            }
+        }
+        catch {
+            throw $_
+        }
+    }
+}

--- a/NetScaler/Public/New-NSLDAPAuthenticationPolicy.ps1
+++ b/NetScaler/Public/New-NSLDAPAuthenticationPolicy.ps1
@@ -1,0 +1,87 @@
+<#
+Copyright 2016 Iain Brighton
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+#>
+
+function New-NSLDAPAuthenticationPolicy {
+    <#
+    .SYNOPSIS
+        Creates a new LDAP authentication policy object.
+
+    .DESCRIPTION
+        Creates a new LDAP authentication policy object.
+
+    .PARAMETER Session
+        The NetScaler session object.
+
+    .PARAMETER Name
+        The name of the LDAP authentication policy object to create.
+
+    .PARAMETER Rule
+        Name of the NetScaler named rule, or a default syntax expression, that the policy uses to determine whether to attempt to authenticate the user with the LDAP server..
+
+    .PARAMETER Action
+        Name of the LDAP action (server) to perform if the policy matches.
+
+    .PARAMETER Passthru
+        Return the LDAP authentication policy object.
+
+    .EXAMPLE
+        New-NSLDAPAuthenticationPolicy -Name 'policy_ldap_dc1' -Rule 'ns_true' -Action 'ldap_dc1'
+
+        Creates a new LDAP authentication policy named 'policy_ldap_dc1'.
+    #>
+    [cmdletbinding(SupportsShouldProcess = $true, ConfirmImpact = 'Low')]
+    param (
+        $Session = $Script:Session,
+
+        [parameter(Mandatory, Position=0)]
+        [string]$Name,
+
+        [parameter(Mandatory)]
+        [string]$Rule,
+
+        [parameter(Mandatory)]
+        [string]$Action,
+
+        [switch] $PassThru
+    )
+
+    begin {
+        _AssertSessionActive
+    }
+
+    process {
+        if ($PSCmdlet.ShouldProcess($Name, 'Add LDAP Authentication Policy')) {
+            try {
+                $params = @{
+                    name = $Name
+                    rule = $Rule
+                }
+                if ($PSBoundParameters.ContainsKey('Action')) {
+                    $params.Add('reqaction', $Action)
+                }
+
+                _InvokeNSRestApi -Session $Session -Method POST -Type authenticationldappolicy -Payload $params -Action add
+
+                if ($PSBoundParameters.ContainsKey('PassThru')) {
+                    return Get-NSLDAPAuthenticationPolicy -Session $Session -Name $Name
+                }
+            }
+            catch {
+                throw $_
+            }
+        }
+    }
+}

--- a/NetScaler/Public/New-NSLDAPAuthenticationServer.ps1
+++ b/NetScaler/Public/New-NSLDAPAuthenticationServer.ps1
@@ -1,0 +1,169 @@
+<#
+Copyright 2016 Iain Brighton
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+#>
+
+function New-NSLDAPAuthenticationServer {
+    <#
+    .SYNOPSIS
+        Creates a new LDAP authentication server object.
+
+    .DESCRIPTION
+        Creates a new LDAP authentication server object.
+
+    .PARAMETER Session
+        The NetScaler session object.
+
+    .PARAMETER Name
+        The name LDAP authentication servers object to create.
+
+    .PARAMETER IPAddress
+        The IP address of the LDAP server used to perform queries.
+
+    .PARAMETER ServerName
+        The FQDN of the LDAP server used to perform queries.
+
+    .PARAMETER Port
+        Port on which the LDAP server accepts connections.
+
+        Default value: 389
+
+    .PARAMETER BaseDN
+        Base (node) from which to start LDAP searches.
+
+    .PARAMETER SecurityType
+        Type of security used for communications between the NetScaler appliance and the LDAP server. For the PLAINTEXT setting, no encryption is required.
+
+        Default value: PLAINTEXT
+        Possible values: PLAINTEXT, TLS, SSL
+
+    .PARAMETER ServerType
+        The type of LDAP server.
+
+        Possible values: AD, NDS
+
+    .PARAMETER Credential
+        LDAP login credential with the Full distinguished name (DN) that is used to bind to the LDAP server.
+        The NetScaler appliance uses the login to query external LDAP servers or Active Directory.
+
+    .PARAMETER LoginAttributeName
+        LDAP login name attribute. The NetScaler appliance uses the LDAP login name to query external LDAP servers or Active Directories
+
+    .PARAMETER GroupAttributeName
+        LDAP group attribute name used for group extraction on the LDAP server.
+
+    .PARAMETER SSOAttributeName
+        LDAP single signon (SSO) attribute. The NetScaler appliance uses the SSO name attribute to query external LDAP servers or Active Directory for an alternate username.
+
+    .PARAMETER Passthru
+        Return the LDAP authentication server object.
+
+    .EXAMPLE
+        New-NSLDAPAuthenticationServer -Name ldap_DC1 -ServerName dc1.lab.local -BaseDN 'dc=lab,dc=local' -SecurityType PLAINTEXT -ServerType AD
+
+        Creates a new LDAP authentication server to a server with the name 'dc1.lab.local' using plain LDAP
+
+    .EXAMPLE
+        New-NSLDAPAuthenticationServer -Name ldaps_DC1 -IPAddress 192.168.0.1 -BaseDN 'dc=lab,dc=local' -SecurityType SSL -Port 636 -ServerType AD -Credential (Get-Credential 'administrator@lab.local')
+
+        Creates a new secure LDAP authentication server to a server with the IP address '192.168.0.1' using secure LDAP with the bind credentials supplied.
+    #>
+    [cmdletbinding(SupportsShouldProcess = $true, ConfirmImpact = 'Low', DefaultParameterSetName = 'IPAddress')]
+    param (
+        $Session = $Script:Session,
+
+        [parameter(Mandatory)]
+        [string] $Name,
+
+        [parameter(ParameterSetName = 'IPAddress')]
+        [string] $IPAddress,
+
+        [parameter(ParameterSetName = 'FQDN')]
+        [System.String] $ServerName,
+
+        [int]$Port,
+
+        [ValidateSet('PLAINTEXT','TLS','SSL')]
+        [string] $SecurityType = 'PLAINTEXT',
+
+        [ValidateSet('AD','NDS')]
+        [string] $ServerType,
+
+        [string] $BaseDN,
+
+        [PSCredential] [System.Management.Automation.CredentialAttribute()] $Credential,
+
+        [string] $LoginAttributeName,
+
+        [string] $GroupAttributeName,
+
+        [string] $SSOAttributeName,
+
+        [switch] $PassThru
+    )
+
+    begin {
+        _AssertSessionActive
+    }
+
+    process {
+        if ($PSCmdlet.ShouldProcess($Name, "Add LDAP Authentication Server")) {
+            try {
+                $params = @{
+                    name = $Name
+                }
+                if ($PSBoundParameters.ContainsKey('IPAddress')) {
+                    $params.Add('serverip', $IPAddress)
+                }
+                if ($PSBoundParameters.ContainsKey('ServerName')) {
+                    $params.Add('servername', $ServerName)
+                }
+                if ($PSBoundParameters.ContainsKey('Port')) {
+                    $params.Add('serverport', $Port)
+                }
+                if ($PSBoundParameters.ContainsKey('BaseDN')) {
+                    $params.Add('ldapbase', $BaseDN)
+                }
+                if ($PSBoundParameters.ContainsKey('Credential')) {
+                    $params.Add('ldapbinddn', $Credential.UserName)
+                    $params.Add('ldapbinddnpassword', $Credential.GetNetworkCredential().Password)
+                }
+                if ($PSBoundParameters.ContainsKey('LoginAttributeName')) {
+                    $params.Add('ldaploginname', $LoginAttributeName)
+                }
+                if ($PSBoundParameters.ContainsKey('GroupAttributeName')) {
+                    $params.Add('groupattrname', $GroupAttributeName)
+                }
+                if ($PSBoundParameters.ContainsKey('SecurityType')) {
+                    $params.Add('sectype', $SecurityType)
+                }
+                if ($PSBoundParameters.ContainsKey('ServerType')) {
+                    $params.Add('svrtype', $ServerType)
+                }
+                if ($PSBoundParameters.ContainsKey('SSOAttributeName')) {
+                    $params.Add('ssonameattribute', $SSOAttributeName)
+                }
+
+                _InvokeNSRestApi -Session $Session -Method POST -Type authenticationldapaction -Payload $params -Action add
+
+                if ($PSBoundParameters.ContainsKey('PassThru')) {
+                    return Get-NSLDAPAuthenticationServer -Session $Session -Name $Name
+                }
+            }
+            catch {
+                throw $_
+            }
+        }
+    }
+}

--- a/NetScaler/Public/New-NSSSLProfile.ps1
+++ b/NetScaler/Public/New-NSSSLProfile.ps1
@@ -1,0 +1,184 @@
+<#
+Copyright 2016 Iain Brighton
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+#>
+
+function New-NSSSLProfile {
+    <#
+    .SYNOPSIS
+        Creates a new SSL profile.
+
+    .DESCRIPTION
+        Creates a new SSL profile.
+
+    .PARAMETER Session
+        The NetScaler session object.
+
+    .PARAMETER Name
+        Name of the SSL profile
+
+    .PARAMETER SSL2
+        State of SSLv2 protocol support for the SSL profile.
+
+        Default value: DISABLED
+
+    .PARAMETER SSL3
+        State of SSLv3 protocol support for the SSL profile.
+
+        Default value: ENABLED
+
+    .PARAMETER TLS1
+        State of TLSv1.0 protocol support for the SSL profile.
+
+        Default value: ENABLED
+
+    .PARAMETER TLS11
+        State of TLSv1.1 protocol support for the SSL profile.
+
+        Default value: ENABLED
+
+    .PARAMETER TLS12
+        State of TLSv1.2 protocol support for the SSL profile.
+
+        Default value: ENABLED
+
+    .PARAMETER DenySslRenegotiation
+        Deny renegotiation in specified circumstances.
+
+        Default value: All
+
+    .PARAMETER DH
+        State of Diffie-Hellman (DH) key exchange.
+
+        Default value: DISABLED
+
+    .PARAMETER DHFile
+        Name of and, optionally, path to the DH parameter file, in PEM format, to be installed. /nsconfig/ssl/ is the default path.
+
+    .PARAMETER DHCount
+        Number of interactions, between the client and the NetScaler appliance, after which the DH private-public pair is regenerated. A value of zero (0) specifies infinite use (no refresh).
+
+    .PARAMETER DHKeyExpSizeLimit
+        This option enables the use of NIST recommended (NIST Special Publication 800-56A) bit size for private-key size. For example, for DH params of size 2048bit, the private-key size recommended is 224bits. This is rounded-up to 256bits.
+
+        Default value: DISABLED
+
+    .PARAMETER ProfileType
+        Type of profile. Front end profiles apply to the entity that receives requests from a client. Backend profiles apply to the entity that sends client requests to a server.
+
+        Default value: FrontEnd
+
+    .EXAMPLE
+        New-NSSSLProfile -Name "Secure_SSL_Profile" -ProfileType "FrontEnd" -SSL3 $false -TLS1 $true -TLS11 $true -TLS12 $true -DenySslRenegotiation "FRONTEND_CLIENT"
+
+        Creates a new SSL profile named 'Secure_SSL_Profile'.
+
+    .PARAMETER Passthru
+        Return the load balancer server object.
+    #>
+    [cmdletbinding(SupportsShouldProcess = $true, ConfirmImpact = 'Low')]
+    param(
+        $Session = $script:session,
+
+        [parameter(Mandatory)]
+        [String]$Name,
+
+        [ValidateSet('NO','FRONTEND_CLIENT','FRONTENT_CLIENTSERVER','ALL','NONSECURE')]
+        [string]$DenySslRenegotiation,
+
+        [ValidateSet('FrontEnd','BackEnd')]
+        [string]$ProfileType,
+
+        [ValidateSet('ENABLED','DISABLED')]
+        [string]$SSL2,
+
+        [ValidateSet('ENABLED','DISABLED')]
+        [string]$SSL3,
+
+        [ValidateSet('ENABLED','DISABLED')]
+        [string]$TLS1,
+
+        [ValidateSet('ENABLED','DISABLED')]
+        [string]$TLS11,
+
+        [ValidateSet('ENABLED','DISABLED')]
+        [string]$TLS12,
+
+        [ValidateSet('ENABLED','DISABLED')]
+        [string]$DH,
+
+        [string]$DHFile,
+
+        [ValidateRange(0,65534)]
+        [int]$DHCount,
+
+        [ValidateSet('ENABLED','DISABLED')]
+        [string]$DHKeyExpSizeLimit,
+
+        [Switch]$PassThru
+    )
+
+    begin {
+        _AssertSessionActive
+    }
+
+    process {
+        if ($PSCmdlet.ShouldProcess($Name, 'Create SSL Profile')) {
+            try {
+                $params = @{
+                    name = $Name
+                }
+                if ($PSBoundParameters.ContainsKey('DenySslRenegotiation')) {
+                    $params.Add('denysslreneg', $DenySslRenegotiation)
+                }
+                if ($PSBoundParameters.ContainsKey('SSL2')) {
+                    $params.Add('ssl2', $SSL2)
+                }
+                if ($PSBoundParameters.ContainsKey('SSL3')) {
+                    $params.Add('ssl3', $SSL3)
+                }
+                if ($PSBoundParameters.ContainsKey('TLS1')) {
+                    $params.Add('tls1', $TLS1)
+                }
+                if ($PSBoundParameters.ContainsKey('TLS11')) {
+                    $params.Add('tls11', $TLS11)
+                }
+                if ($PSBoundParameters.ContainsKey('TLS12')) {
+                    $params.Add('tls12', $TLS12)
+                }
+                if ($PSBoundParameters.ContainsKey('DH')) {
+                    $params.Add('dh', $DH)
+                }
+                if ($PSBoundParameters.ContainsKey('DHFile')) {
+                    $params.Add('dhfile', $DHFile)
+                }
+                if ($PSBoundParameters.ContainsKey('DHCount')) {
+                    $params.Add('dhcount', $DHCount)
+                }
+                if ($PSBoundParameters.ContainsKey('DHKeyExpSizeLimit')) {
+                    $params.Add('dhkeyexpsizelimit', $DHKeyExpSizeLimit)
+                }
+
+                _InvokeNSRestApi -Session $Session -Method POST -Type sslprofile -Payload $params -Action add
+
+                if ($PSBoundParameters.ContainsKey('PassThru')) {
+                    return (Get-NSSSLProfile -Session $session -Name $Name)
+                }
+            }
+            catch {
+                throw $_
+            }
+        }
+    }
+}

--- a/NetScaler/Public/New-NSVPNSessionPolicy.ps1
+++ b/NetScaler/Public/New-NSVPNSessionPolicy.ps1
@@ -1,0 +1,95 @@
+<#
+Copyright 2016 Iain Brighton
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+#>
+
+function New-NSVPNSessionPolicy {
+    <#
+    .SYNOPSIS
+        Create NetScaler Gateway session policy resource.
+
+    .DESCRIPTION
+        Create NetScaler Gateway session policy resource.
+
+    .PARAMETER Session
+        The NetScaler session object.
+
+    .PARAMETER Name
+        Name for the NetScaler Gateway profile (action). Must begin with an ASCII alphabetic or underscore (_) character, and must consist only of ASCII alphanumeric, underscore, hash (#), period (.), space, colon (:), at (@), equals (=), and hyphen (-) characters. Cannot be changed after the profile is created. The following requirement applies only to the NetScaler CLI: If the name includes one or more spaces, enclose the name in double or single quotation marks (for example, "my action" or 'my action').
+
+        Minimum length = 1
+
+    .PARAMETER SessionProfileName
+        Session profile (Action) to be applied by the new session policy if the rule criteria are met.
+
+        Minimum length = 1
+
+    .PARAMETER Rule
+        Expression, or name of a named expression, specifying the traffic that matches the policy. Can be written in either default or classic syntax. Maximum length of a string literal in the expression is 255 characters. A longer string can be split into smaller strings of up to 255 characters each, and the smaller strings concatenated with the + operator. For example, you can create a 500-character string as follows: '"<string of 255 characters>" + "<string of 245 characters>"' The following requirements apply only to the NetScaler CLI: * If the expression includes one or more spaces, enclose the entire expression in double quotation marks. * If the expression itself includes double quotation marks, escape the quotations by using the \ character. * Alternatively, you can use single quotation marks to enclose the rule, in which case you do not have to escape the double quotation marks.
+
+    .PARAMETER Passthru
+        Return the NetScaler Gateway session profile object.
+
+    .PARAMETER Force
+        Suppress confirmation when creating the NetScaler Gateway session profile.
+
+    .EXAMPLE
+        New-NSVPNSessionPolicy -Session $Session -Name "prof_receiver" -SessionProfileName "session_receiver" -Rule "REQ.HTTP.HEADER User-Agent CONTAINS CitrixReceiver"
+
+        Creates a new NetScaler Gateway session policy named 'prof_receiver'.
+    #>
+    [cmdletbinding(SupportsShouldProcess = $true, ConfirmImpact = 'Low')]
+    param (
+        $Session = $script:session,
+
+        [parameter(Mandatory)]
+        [string]$Name,
+
+        [parameter(Mandatory)]
+        [alias('ProfileName')]
+        [string]$SessionProfileName,
+
+        [parameter(Mandatory)]
+        [string]$Rule,
+
+        [switch]$Force,
+
+        [switch]$PassThru
+    )
+
+    begin {
+        _AssertSessionActive
+    }
+
+    process {
+        if ($Force -or $PSCmdlet.ShouldProcess($Name, 'Add NetScaler Gateway Session Policy')) {
+            try {
+                $params = @{
+                    name = $Name
+                    action = $SessionProfileName
+                    rule = $Rule
+                }
+
+                _InvokeNSRestApi -Session $Session -Method POST -Type vpnsessionpolicy -Payload $params
+
+                if ($PSBoundParameters.ContainsKey('PassThru')) {
+                    return Get-NSVPNSessionPolicy -Session $Session -Name $Name
+                }
+            }
+            catch {
+                throw $_
+            }
+        }
+    }
+}

--- a/NetScaler/Public/New-NSVPNSessionProfile.ps1
+++ b/NetScaler/Public/New-NSVPNSessionProfile.ps1
@@ -1,0 +1,186 @@
+<#
+Copyright 2016 Iain Brighton
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+#>
+
+function New-NSVPNSessionProfile {
+    <#
+    .SYNOPSIS
+        Create NetScaler Gateway session profile resource.
+
+    .DESCRIPTION
+        Create NetScaler Gateway session profile resource.
+
+    .PARAMETER Session
+        The NetScaler session object.
+
+    .PARAMETER Name
+        Name for the NetScaler Gateway profile (action). Must begin with an ASCII alphabetic or underscore (_) character, and must consist only of ASCII alphanumeric, underscore, hash (#), period (.), space, colon (:), at (@), equals (=), and hyphen (-) characters. Cannot be changed after the profile is created. The following requirement applies only to the NetScaler CLI: If the name includes one or more spaces, enclose the name in double or single quotation marks (for example, "my action" or 'my action').
+
+        Minimum length = 1
+
+    .PARAMETER TransparentInterception
+        Switch parameter. Allow access to network resources by using a single IP address and subnet mask or a range of IP addresses.
+        When turned off,  sets the mode to proxy, in which you configure destination and source IP addresses and port numbers.
+        If you are using the NetScale Gateway Plug-in for Windows, turn it on, in which the mode is set to transparent.
+        If you are using the NetScale Gateway Plug-in for Java, turn it off.
+
+    .PARAMETER SplitTunnel
+        Send, through the tunnel, traffic only for intranet applications that are defined in NetScaler Gateway.
+        Route all other traffic directly to the Internet.
+        The OFF setting routes all traffic through Access Gateway.
+        With the REVERSE setting, intranet applications define the network traffic that is not intercepted.All network traffic directed to internal IP addresses bypasses the VPN tunnel, while other traffic goes through Access Gateway.
+        Reverse split tunneling can be used to log all non-local LAN traffic.
+
+        Possible values: ON, OFF, REVERSE
+
+    .PARAMETER DefaultAuthorizationAction
+        Specify the network resources that users have access to when they log on to the internal network.
+
+        Default value: DENY which deny access to all network resources.
+        Possible values: ALLOW, DENY
+
+    .PARAMETER SSO
+        Set single sign-on (SSO) for the session. When the user accesses a server, the user's logon credentials are passed to the server for authentication.
+
+        Possible values: ON, OFF
+
+    .PARAMETER IcaProxy
+        Enable ICA proxy to configure secure Internet access to servers running Citrix XenApp or XenDesktop by using Citrix Receiver instead of the Access Gateway Plug-in.
+
+    .PARAMETER NtDomain
+        Single sign-on domain to use for single sign-on to applications in the internal network.
+        This setting can be overwritten by the domain that users specify at the time of logon or by the domain that the authentication server returns.
+
+        Minimum length: 1
+        Maximum length: 32
+
+    .PARAMETER ClientlessVpnMode
+        Enable clientless access for web, XenApp or XenDesktop, and FileShare resources without installing the Access Gateway Plug-in.
+        Available settings function as follows: * ON - Allow only clientless access. * OFF - Allow clientless access after users log on with the Access Gateway Plug-in. * DISABLED - Do not allow clientless access.
+
+    .PARAMETER ClientChoices
+        Provide users with multiple logon options. With client choices, users have the option of logging on by using the Access Gateway Plug-in for Windows, Access Gateway Plug-in for Java, the Web Interface, or clientless access from one location.
+        Depending on how Access Gateway is configured, users are presented with up to three icons for logon choices. The most common are the Access Gateway Plug-in for Windows, Web Interface, and clientless access.
+
+    .PARAMETER StoreFrontUrl
+        Web address for StoreFront to be used in this session for enumeration of resources from XenApp or XenDesktop.
+
+    .PARAMETER WIHome
+        Web address of the Web Interface server, such as http:///Citrix/XenApp, or Receiver for Web, which enumerates the virtualized resources, such as XenApp, XenDesktop, and cloud applications.
+
+    .PARAMETER Passthru
+        Return the NetScaler Gateway session profile object.
+
+    .PARAMETER Force
+        Suppress confirmation when creating the NetScaler Gateway session profile.
+
+    .EXAMPLE
+        New-NSVPNSessionProfile -Session $Session -Name 'profile_receiver' -NTDomain 'lab.local' -WIHome "https://storefront.lab.local/Citrix/StoreWeb" -StoreFrontUrl "https://storefront.lab.local"
+
+        Creates a new NetScaler Gateway session profile named 'profile_receiver'.
+    #>
+    [cmdletbinding(SupportsShouldProcess = $true, ConfirmImpact = 'Low')]
+    param (
+        $Session = $script:session,
+
+        [parameter(Mandatory)]
+        [string]$Name,
+
+        [ValidateSet("ON","OFF")]
+        [string]$TransparentInterception,
+
+        [ValidateSet("ON","OFF","REVERSE")]
+        [string]$SplitTunnel,
+
+        [ValidateSet("ALLOW","DENY")]
+        [string]$DefaultAuthorizationAction,
+
+        [ValidateSet("ON","OFF")]
+        [string]$SSO,
+
+        [ValidateSet("ON","OFF")]
+        [string]$IcaProxy,
+
+        [string]$NTDomain,
+
+        [ValidateSet("ON","OFF","DISABLED")]
+        [string]$ClientlessVpnMode="OFF",
+
+        [ValidateSet("ON","OFF")]
+        [string]$ClientChoices,
+
+        [string]$StoreFrontUrl,
+
+        [string]$WIHome,
+
+        [switch]$Force,
+
+        [switch]$PassThru
+    )
+
+    begin {
+        _AssertSessionActive
+    }
+
+    process {
+        if ($Force -or $PSCmdlet.ShouldProcess($Name, 'Add NetScaler Gateway Session Profile')) {
+            try {
+                $params = @{
+                    name = $Name
+                }
+                if ($PSBoundParameters.ContainsKey('TransparentInterception')) {
+                    $params.Add('transparentinterception', $TransparentInterception)
+                }
+                if ($PSBoundParameters.ContainsKey('SplitTunnel')) {
+                    $params.Add('splittunnel', $SplitTunnel)
+                }
+                if ($PSBoundParameters.ContainsKey('DefaultAuthorizationAction')) {
+                    $params.Add('defaultauthorizationaction', $DefaultAuthorizationAction)
+                }
+                if ($PSBoundParameters.ContainsKey('SSO')) {
+                    $params.Add('sso', $SSO)
+                }
+                if ($PSBoundParameters.ContainsKey('IcaProxy')) {
+                    $params.Add('icaproxy', $IcaProxy)
+                }
+                if ($PSBoundParameters.ContainsKey('WIHome')) {
+                    $params.Add('wihome', $WIHome)
+                }
+                if ($PSBoundParameters.ContainsKey('ClientChoices')) {
+                    $params.Add('clientchoices', $ClientChoices)
+                }
+                if ($PSBoundParameters.ContainsKey('NTDomain')) {
+                    $params.Add('ntdomain', $NTDomain)
+                }
+                if ($PSBoundParameters.ContainsKey('ClientlessVpnMode')) {
+                    $params.Add('clientlessvpnmode', $ClientlessVpnMode)
+                }
+                if ($PSBoundParameters.ContainsKey('StoreFrontUrl')) {
+                    $params.Add('storefronturl', $StoreFrontUrl)
+                }
+
+                _InvokeNSRestApi -Session $Session -Method POST -Type vpnsessionaction -Payload $params
+
+                if ($PSBoundParameters.ContainsKey('PassThru')) {
+                    return Get-NSVPNSessionProfile -Session $Session -Name $Name
+                }
+            }
+            catch
+            {
+                throw $_
+            }
+        }
+    }
+}

--- a/NetScaler/Public/New-NSVPNVirtualServer.ps1
+++ b/NetScaler/Public/New-NSVPNVirtualServer.ps1
@@ -1,0 +1,125 @@
+<#
+Copyright 2016 Iain Brighton
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+#>
+
+function New-NSVPNVirtualServer {
+    <#
+    .SYNOPSIS
+        Creates a new NetScaler Gateway virtual server.
+
+    .DESCRIPTION
+        Creates a new NetScaler Gateway virtual server.
+
+    .PARAMETER Session
+        The NetScaler session object.
+
+    .PARAMETER Name
+        Name for the NetScaler Gateway virtual server. Must begin with an ASCII alphanumeric or underscore (_) character,
+        and must contain only ASCII alphanumeric, underscore, hash (#), period (.), space, colon (:), at sign (@),
+        equal sign (=), and hyphen (-) characters. Can be changed after the virtual server is created.
+
+        Minimum length = 1
+
+    .PARAMETER IPAddress
+        IPv4 or IPv6 address to assign to the NetScaler Gateway virtual server.
+
+        Default value: DISABLED
+
+    .PARAMETER Comment
+        Any comments that you might want to associate with the NetScaler Gateway virtual server.
+
+    .PARAMETER Port
+        Port number for the virtual server.
+
+        Range 1 - 65535
+
+    .PARAMETER Authentication
+        Require authentication for users connecting to NetScaler Gateway virtual server.
+
+        Default value: ENABLED
+
+    .PARAMETER ICAOnly
+        User can log on in Basic mode only, through either Citrix Receiver or a browser. Users are not allowed to connect by using the NetScaler Gateway Plug-in.
+
+        Default value: OFF
+
+    .EXAMPLE
+        New-NSVPNVirtualServer -Name 'ag01' -IPAddress '192.168.0.100'
+
+        Creates a new NetScaler Gateway virtual server named 'ag01'.
+
+    .PARAMETER Passthru
+        Return the NetScaler Gaetway server object.
+    #>
+    [cmdletbinding(SupportsShouldProcess = $true, ConfirmImpact = 'Low')]
+    param(
+        $Session = $script:session,
+
+        [parameter(Mandatory)]
+        [string]$Name,
+
+        [parameter(Mandatory)]
+        [string]$IPAddress,
+
+        [ValidateRange(1,65535)]
+        [int]$Port=443,
+
+        [ValidateSet('ENABLED','DISABLED')]
+        [string]$Authentication,
+
+        [switch]$ICAOnly,
+
+        [ValidateLength(0, 256)]
+        [string]$Comment,
+
+        [Switch]$PassThru
+    )
+
+    begin {
+        _AssertSessionActive
+    }
+
+    process {
+        if ($PSCmdlet.ShouldProcess($Name, 'Create NetScaler Gateway Virtual Server')) {
+            try {
+                $params = @{
+                    name = $Name
+                    ipv46 = $IPAddress
+                    servicetype = 'SSL'
+                    port = $Port
+                }
+                if ($PSBoundParameters.ContainsKey('Authentication')) {
+                    $params.Add('authentication', $Authentication)
+                }
+                if ($PSBoundParameters.ContainsKey('ICAOnly')) {
+                    $ica = if ($ICAOnly) { 'ON' } else { 'OFF' }
+                    $params.Add('icaonly', $ica)
+                }
+                if ($PSBoundParameters.ContainsKey('Comment')) {
+                    $params.Add('comment', $Comment)
+                }
+
+                _InvokeNSRestApi -Session $Session -Method POST -Type vpnvserver -Payload $params
+
+                if ($PSBoundParameters.ContainsKey('PassThru')) {
+                    return Get-NSVPNVirtualServer -Session $Session -Name $Name
+                }
+            }
+            catch {
+                throw $_
+            }
+        }
+    }
+}

--- a/NetScaler/Public/Remove-NSDnsSuffix.ps1
+++ b/NetScaler/Public/Remove-NSDnsSuffix.ps1
@@ -1,0 +1,69 @@
+<#
+Copyright 2016 Iain Brighton
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+#>
+
+function Remove-NSDnsSuffix {
+    <#
+    .SYNOPSIS
+        Removes a domain name suffix from the NetScaler appliance.
+
+    .DESCRIPTION
+        Removes a domain name suffix from the NetScaler appliance.
+
+    .EXAMPLE
+        Remove-NSDnsSuffix -DNSSuffix 'lab.local'
+
+        Removes the 'lab.local' DNS suffix
+
+    .EXAMPLE
+        'lab.local', 'lab.internal' | Remove-NSDnsSuffix -Session $session
+
+        Removes the 'lab.local' and 'lab.internal' DNS suffixes
+
+    .PARAMETER Session
+        The NetScaler session object.
+
+    .PARAMETER Suffix
+        DNS search suffix to be removed.
+
+    .PARAMETER Force
+        Suppress confirmation when adding a DNS suffix.
+    #>
+    [cmdletbinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
+    param (
+        $Session = $script:session,
+
+        [parameter(Mandatory, ValueFromPipeline)]
+        [string[]]$Suffix,
+
+        [Switch]$Force
+    )
+    begin {
+        _AssertSessionActive
+    }
+
+    process {
+        foreach ($item in $Suffix) {
+             if ($Force -or $PSCmdlet.ShouldProcess($item, 'Delete DNS suffix')) {
+                try {
+                    _InvokeNSRestApi -Session $Session -Method DELETE -Type dnssuffix -Resource $item -Action delete
+                }
+                catch {
+                    throw $_
+                }
+            }
+        }
+    }
+}

--- a/NetScaler/Public/Remove-NSLBMonitor.ps1
+++ b/NetScaler/Public/Remove-NSLBMonitor.ps1
@@ -29,7 +29,7 @@ function Remove-NSLBMonitor {
 
     .EXAMPLE
         'monitor01', 'monitor02' | Remove-NSLBMonitor
-    
+
         Removes the load balancer monitors named 'monitor01' and 'monitor02'.
 
     .PARAMETER Session

--- a/NetScaler/Public/Remove-NSLBSSLVirtualServerProfile.ps1
+++ b/NetScaler/Public/Remove-NSLBSSLVirtualServerProfile.ps1
@@ -1,0 +1,86 @@
+<#
+Copyright 2016 Iain Brighton
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+#>
+
+function Remove-NSLBSSLVirtualServerProfile {
+    <#
+    .SYNOPSIS
+        Remove the existing load balancing virtual server SSL profile.
+
+    .DESCRIPTION
+        Remove the existing load balancing virtual server SSL profile.
+
+    .EXAMPLE
+        Remove-NSLBSSLVirtualServerProfile -Name 'vserver01' -ProfileName 'sslprofile01'
+
+        Sets the 'vserver01' load balancing virtual server's SSL profile to 'sslprofile01'
+
+    .PARAMETER Session
+        The NetScaler session object.
+
+    .PARAMETER Name
+        The name or names of the load balancer virtual servers to set.
+
+    .PARAMETER ProfileName
+        The SSL profile name to assign to the virtual server.
+
+    .PARAMETER Force
+        Suppress confirmation when updating a virtual server.
+
+    .PARAMETER Passthru
+        Return the virtual server object.
+    #>
+    [cmdletbinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
+    param(
+        $Session = $script:session,
+
+        [parameter(Mandatory = $true, ValueFromPipeline = $true, ValueFromPipelineByPropertyName)]
+        [alias('VirtualServerName')]
+        [string[]]$Name,
+
+        [parameter(Mandatory = $true, ValueFromPipelineByPropertyName)]
+        [string]$ProfileName,
+
+        [Switch]$Force,
+
+        [Switch]$PassThru
+    )
+
+    begin {
+        _AssertSessionActive
+    }
+
+    process {
+        foreach ($item in $Name) {
+            if ($Force -or $PSCmdlet.ShouldProcess($item, 'Edit Virtual Server')) {
+                try {
+                    $params = @{
+                        vservername = $item
+                        sslprofile = $ProfileName
+                    }
+
+                    _InvokeNSRestApi -Session $Session -Method POST -Type sslvserver -Payload $params -Action unset
+
+                    if ($PSBoundParameters.ContainsKey('PassThru')) {
+                        return Get-NSLBVirtualServerSslProfile -Session $Session -Name $item
+                    }
+                }
+                catch {
+                    throw $_
+                }
+            }
+        }
+    }
+}

--- a/NetScaler/Public/Remove-NSLBServiceGroupMonitorBinding.ps1
+++ b/NetScaler/Public/Remove-NSLBServiceGroupMonitorBinding.ps1
@@ -1,0 +1,75 @@
+<#
+Copyright 2016 Iain Brighton
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+#>
+
+function Remove-NSLBServiceGroupMonitorBinding {
+    <#
+    .SYNOPSIS
+        Removes a monitor binding from a service group.
+
+    .DESCRIPTION
+        Removes a monitor binding from a service group.
+
+    .PARAMETER Session
+        The NetScaler session object.
+
+    .PARAMETER Name
+        The name of the service group to unbind the monitor.
+
+    .PARAMETER MonitorName
+        The name of the monitor to unbind.
+
+    .EXAMPLE
+        Remove-NSLBServiceGroupMonitorBinding -Name 'sg01' -MonitorName 'mon01'
+
+        Unbinds the monitor named 'mon01' from the service group 'sg01'.
+
+    .PARAMETER Force
+        Suppress confirmation when removing a responder action.
+    #>
+    [cmdletbinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
+    param(
+        $Session = $script:session,
+
+        [parameter(Mandatory = $true, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [alias('ServiceGroupName')]
+        [string[]]$Name,
+
+        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [string]$MonitorName,
+
+        [switch]$Force
+    )
+
+    begin {
+        _AssertSessionActive
+    }
+
+    process {
+
+        $params =@{
+            monitor_name = $MonitorName
+        }
+        foreach ($item in $Name) {
+            if ($Force -or $PSCmdlet.ShouldProcess($item, 'Delete Monitor Binding')) {
+                try {
+                    _InvokeNSRestApi -Session $Session -Method DELETE -Type servicegroup_lbmonitor_binding -Resource $item -Arguments $params -Action delete
+                } catch {
+                    throw $_
+                }
+            }
+        }
+    }
+}

--- a/NetScaler/Public/Remove-NSLDAPAuthenticationPolicy.ps1
+++ b/NetScaler/Public/Remove-NSLDAPAuthenticationPolicy.ps1
@@ -1,5 +1,5 @@
 <#
-Copyright 2015 Brandon Olin
+Copyright 2016 Iain Brighton
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,39 +14,34 @@ See the License for the specific language governing permissions and
 limitations under the License.
 #>
 
-function Remove-NSLBServer {
+function Remove-NSLDAPAuthenticationPolicy {
     <#
     .SYNOPSIS
-        Removes a load balancer server.
+        Removes an existing LDAP authentication policy.
 
     .DESCRIPTION
-        Removes a load balancer server.
-
-    .EXAMPLE
-        Remove-NSLBServer -Name 'server01'
-
-        Removes the load balancer server named 'server01'.
-
-    .EXAMPLE
-        'server01', 'server02' | Remove-NSLBServer
-
-        Removes the load balancer servers named 'server01' and 'server02'.
+        Removes an existing LDAP authentication policy.
 
     .PARAMETER Session
         The NetScaler session object.
 
     .PARAMETER Name
-        The name or names of the load balancer server to get.
+        The name of the LDAP authentication policy to remove.
+
+    .EXAMPLE
+        Remove-NSLDAPAuthenticationPolicy -Name 'pol_ldap_DC1'
+
+        Removes the LDAP authentication policy named 'pol_ldap_DC1'.
 
     .PARAMETER Force
-        Suppress confirmation when removing a load balancer server.
+        Suppress confirmation when removing a responder action.
     #>
-    [cmdletbinding(SupportsShouldProcess = $true, ConfirmImpact='High')]
+    [cmdletbinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
     param(
         $Session = $script:session,
 
         [parameter(Mandatory = $true, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
-        [string[]]$Name = (Read-Host -Prompt 'LB server name'),
+        [string[]]$Name,
 
         [switch]$Force
     )
@@ -57,10 +52,11 @@ function Remove-NSLBServer {
 
     process {
         foreach ($item in $Name) {
-            if ($Force -or $PSCmdlet.ShouldProcess($item, 'Delete Server')) {
+            if ($Force -or $PSCmdlet.ShouldProcess($item, 'Delete LDAP Authentication Policy')) {
                 try {
-                    _InvokeNSRestApi -Session $Session -Method DELETE -Type server -Resource $item -Action delete
-                } catch {
+                    _InvokeNSRestApi -Session $Session -Method DELETE -Type authenticationldappolicy -Resource $item -Action delete
+                }
+                catch {
                     throw $_
                 }
             }

--- a/NetScaler/Public/Remove-NSLDAPAuthenticationServer.ps1
+++ b/NetScaler/Public/Remove-NSLDAPAuthenticationServer.ps1
@@ -1,5 +1,5 @@
 <#
-Copyright 2015 Brandon Olin
+Copyright 2016 Iain Brighton
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,39 +14,34 @@ See the License for the specific language governing permissions and
 limitations under the License.
 #>
 
-function Remove-NSLBServer {
+function Remove-NSLDAPAuthenticationServer {
     <#
     .SYNOPSIS
-        Removes a load balancer server.
+        Removes an existing LDAP authentication server.
 
     .DESCRIPTION
-        Removes a load balancer server.
-
-    .EXAMPLE
-        Remove-NSLBServer -Name 'server01'
-
-        Removes the load balancer server named 'server01'.
-
-    .EXAMPLE
-        'server01', 'server02' | Remove-NSLBServer
-
-        Removes the load balancer servers named 'server01' and 'server02'.
+        Removes an existing LDAP authentication server.
 
     .PARAMETER Session
         The NetScaler session object.
 
     .PARAMETER Name
-        The name or names of the load balancer server to get.
+        The name of the LDAP authentication server to remove.
+
+    .EXAMPLE
+        Remove-NSLDAPAuthenticationServer -Name 'ldap_DC1'
+
+        Removes the LDAP authentication server named 'ldap_DC1'.
 
     .PARAMETER Force
-        Suppress confirmation when removing a load balancer server.
+        Suppress confirmation when removing a responder action.
     #>
-    [cmdletbinding(SupportsShouldProcess = $true, ConfirmImpact='High')]
+    [cmdletbinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
     param(
         $Session = $script:session,
 
         [parameter(Mandatory = $true, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
-        [string[]]$Name = (Read-Host -Prompt 'LB server name'),
+        [string[]]$Name,
 
         [switch]$Force
     )
@@ -57,10 +52,11 @@ function Remove-NSLBServer {
 
     process {
         foreach ($item in $Name) {
-            if ($Force -or $PSCmdlet.ShouldProcess($item, 'Delete Server')) {
+            if ($Force -or $PSCmdlet.ShouldProcess($item, 'Delete LDAP Authentication Server')) {
                 try {
-                    _InvokeNSRestApi -Session $Session -Method DELETE -Type server -Resource $item -Action delete
-                } catch {
+                    _InvokeNSRestApi -Session $Session -Method DELETE -Type authenticationldapaction -Resource $item -Action delete
+                }
+                catch {
                     throw $_
                 }
             }

--- a/NetScaler/Public/Remove-NSSSLCertificateLink.ps1
+++ b/NetScaler/Public/Remove-NSSSLCertificateLink.ps1
@@ -1,0 +1,61 @@
+<#
+Copyright 2016 Iain Brighton
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+#>
+
+function Remove-NSSSLCertificateLink {
+    <#
+    .SYNOPSIS
+        Removes a SSL certificate link from an intermediate certificate.
+
+    .DESCRIPTION
+        Removes a SSL certificate link from an intermediate certificate.
+
+    .EXAMPLE
+        Remove-NSSSLCertificateLink -CertKeyName 'mycert'
+
+        Deletes associated/chained certificates linked to the 'mycert' key pair.
+
+    .PARAMETER Session
+        The NetScaler session object.
+
+    .PARAMETER CertKeyName
+        Name of the certificate key pair to add the link to.
+    #>
+    [cmdletbinding(SupportsShouldProcess = $true, ConfirmImpact='Low')]
+    param(
+        $Session = $script:session,
+
+        [Parameter(Mandatory)]
+        [string]$CertKeyName
+    )
+
+    begin {
+        _AssertSessionActive
+    }
+
+    process {
+        if ($PSCmdlet.ShouldProcess($CertKeyName, 'Delete SSL certificate link')) {
+            try {
+                $params = @{
+                    certkey = $CertKeyName
+                }
+                $response = _InvokeNSRestApi -Session $Session -Method POST -Type sslcertkey -Payload $params -Action unlink
+            }
+            catch {
+                throw $_
+            }
+        }
+    }
+}

--- a/NetScaler/Public/Remove-NSSSLProfile.ps1
+++ b/NetScaler/Public/Remove-NSSSLProfile.ps1
@@ -1,5 +1,5 @@
 <#
-Copyright 2015 Brandon Olin
+Copyright 2016 Iain Brighton
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,39 +14,34 @@ See the License for the specific language governing permissions and
 limitations under the License.
 #>
 
-function Remove-NSLBServer {
+function Remove-NSSSLProfile {
     <#
     .SYNOPSIS
-        Removes a load balancer server.
+        Removes a SSL profile.
 
     .DESCRIPTION
-        Removes a load balancer server.
-
-    .EXAMPLE
-        Remove-NSLBServer -Name 'server01'
-
-        Removes the load balancer server named 'server01'.
-
-    .EXAMPLE
-        'server01', 'server02' | Remove-NSLBServer
-
-        Removes the load balancer servers named 'server01' and 'server02'.
+        Removes a SSL profile.
 
     .PARAMETER Session
         The NetScaler session object.
 
     .PARAMETER Name
-        The name or names of the load balancer server to get.
+        The name of the SSL profile to remove.
+
+    .EXAMPLE
+        Remove-NSSSLProfile -Name 'Secure_SSL_Profile'
+
+        Removes the SSL profile named 'Secure_SSL_Profile'.
 
     .PARAMETER Force
-        Suppress confirmation when removing a load balancer server.
+        Suppress confirmation when removing a responder action.
     #>
-    [cmdletbinding(SupportsShouldProcess = $true, ConfirmImpact='High')]
+    [cmdletbinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
     param(
         $Session = $script:session,
 
         [parameter(Mandatory = $true, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
-        [string[]]$Name = (Read-Host -Prompt 'LB server name'),
+        [string[]]$Name,
 
         [switch]$Force
     )
@@ -57,9 +52,9 @@ function Remove-NSLBServer {
 
     process {
         foreach ($item in $Name) {
-            if ($Force -or $PSCmdlet.ShouldProcess($item, 'Delete Server')) {
+            if ($Force -or $PSCmdlet.ShouldProcess($item, 'Delete SSL Profile')) {
                 try {
-                    _InvokeNSRestApi -Session $Session -Method DELETE -Type server -Resource $item -Action delete
+                    _InvokeNSRestApi -Session $Session -Method DELETE -Type sslprofile -Resource $item -Action delete
                 } catch {
                     throw $_
                 }

--- a/NetScaler/Public/Remove-NSVPNSessionPolicy.ps1
+++ b/NetScaler/Public/Remove-NSVPNSessionPolicy.ps1
@@ -1,0 +1,64 @@
+<#
+Copyright 2016 Iain Brighton
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+#>
+
+function Remove-NSVPNSessionPolicy {
+    <#
+    .SYNOPSIS
+        Delete an existing NetScaler Gateway session policy resource.
+
+    .DESCRIPTION
+        Delete an existing NetScaler Gateway session policy resource.
+
+    .PARAMETER Session
+        The NetScaler session object.
+
+    .PARAMETER Name
+        Name of the NetScaler Gateway session policy to remove.
+
+        Minimum length = 1
+
+    .PARAMETER Force
+        Suppress confirmation when creating the NetScaler Gateway session profile.
+
+    .EXAMPLE
+        Remove-NSVPNSessionPolicy -Session $Session -Name 'POL_OS_10.108.151.1_S'
+
+        Deletes the NetScaler Gateway sesison policy named 'POL_OS_10.108.151.1_S'
+    #>
+    [cmdletbinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
+    param (
+        $Session = $script:session,
+
+        [parameter(Mandatory)]
+        [string]$Name,
+
+        [switch]$Force
+    )
+
+    begin {
+        _AssertSessionActive
+    }
+
+    process {
+        if ($Force -or $PSCmdlet.ShouldProcess($Name, 'Delete NetScaler Gateway Session Policy')) {
+            try {
+                _InvokeNSRestApi -Session $Session -Method Delete -Type vpnsessionpolicy -Resource $Name
+            } catch {
+                throw $_
+            }
+        }
+    }
+}

--- a/NetScaler/Public/Remove-NSVPNSessionProfile.ps1
+++ b/NetScaler/Public/Remove-NSVPNSessionProfile.ps1
@@ -1,0 +1,65 @@
+<#
+Copyright 2016 Iain Brighton
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+#>
+
+function Remove-NSVPNSessionProfile {
+    <#
+    .SYNOPSIS
+        Delete an existing NetScaler Gateway session profile resource.
+
+    .DESCRIPTION
+        Delete an existing NetScaler Gateway session profile resource.
+
+    .PARAMETER Session
+        The NetScaler session object.
+
+    .PARAMETER Name
+        Name of the NetScaler Gateway session profile (action) to remove.
+
+        Minimum length = 1
+
+    .PARAMETER Force
+        Suppress confirmation when creating the NetScaler Gateway session profile.
+
+    .EXAMPLE
+        Remove-NSVPNSessionProfile -Session $Session -Name 'prof_receiver'
+
+        Deletes the NetScaler Gateway session profile named 'prof_receiver'.
+    #>
+    [cmdletbinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
+    param (
+        $Session = $script:session,
+
+        [parameter(Mandatory)]
+        [string]$Name,
+
+        [switch]$Force
+    )
+
+    begin {
+        _AssertSessionActive
+    }
+
+    process {
+        if ($Force -or $PSCmdlet.ShouldProcess($Name, 'Delete NetScaler Gateway Session Profile')) {
+            try {
+                _InvokeNSRestApi -Session $Session -Method Delete -Type vpnsessionaction -Resource $Name
+            }
+            catch {
+                throw $_
+            }
+        }
+    }
+}

--- a/NetScaler/Public/Set-NSLBSSLVirtualServerProfile.ps1
+++ b/NetScaler/Public/Set-NSLBSSLVirtualServerProfile.ps1
@@ -71,7 +71,7 @@ function Set-NSLBSSLVirtualServerProfile {
                         sslprofile = $ProfileName;
                     }
 
-                    _InvokeNSRestApi -Session $Session -Method PUT -Type sslvserver -Payload $params -Action update
+                    _InvokeNSRestApi -Session $Session -Method PUT -Type sslvserver -Payload $params
 
                     if ($PSBoundParameters.ContainsKey('PassThru')) {
                         return Get-NSLBVirtualServerSslProfile -Session $Session -Name $item

--- a/NetScaler/Public/Set-NSLBSSLVirtualServerProfile.ps1
+++ b/NetScaler/Public/Set-NSLBSSLVirtualServerProfile.ps1
@@ -1,0 +1,86 @@
+<#
+Copyright 2016 Iain Brighton
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+#>
+
+function Set-NSLBSSLVirtualServerProfile {
+    <#
+    .SYNOPSIS
+        Updates an existing load balancing virtual server's SSL profile.
+
+    .DESCRIPTION
+        Updates an existing load balancing virtual server's SSL profile.
+
+    .EXAMPLE
+        Set-NSLBSSLVirtualServerProfile -Name 'vserver01' -ProfileName 'sslprofile01'
+
+        Sets the load balancing virtual server SSL profile to 'sslprofile01'
+
+    .PARAMETER Session
+        The NetScaler session object.
+
+    .PARAMETER Name
+        The name or names of the load balancer virtual servers to set.
+
+    .PARAMETER ProfileName
+        The SSL profile name to assign to the virtual server.
+
+    .PARAMETER Force
+        Suppress confirmation when updating a virtual server.
+
+    .PARAMETER Passthru
+        Return the virtual server object.
+    #>
+    [cmdletbinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
+    param(
+        $Session = $script:session,
+
+        [parameter(Mandatory = $true, ValueFromPipeline = $true, ValueFromPipelineByPropertyName)]
+        [alias('VirtualServerName')]
+        [string[]]$Name,
+
+        [parameter(Mandatory = $true, ValueFromPipelineByPropertyName)]
+        [string]$ProfileName,
+
+        [Switch]$Force,
+
+        [Switch]$PassThru
+    )
+
+    begin {
+        _AssertSessionActive
+    }
+
+    process {
+        foreach ($item in $Name) {
+            if ($Force -or $PSCmdlet.ShouldProcess($item, 'Edit Virtual Server')) {
+                try {
+                    $params = @{
+                        vservername = $item;
+                        sslprofile = $ProfileName;
+                    }
+
+                    _InvokeNSRestApi -Session $Session -Method PUT -Type sslvserver -Payload $params -Action update
+
+                    if ($PSBoundParameters.ContainsKey('PassThru')) {
+                        return Get-NSLBVirtualServerSslProfile -Session $Session -Name $item
+                    }
+                }
+                catch {
+                    throw $_
+                }
+            }
+        }
+    }
+}

--- a/NetScaler/Public/Set-NSSSLProfile.ps1
+++ b/NetScaler/Public/Set-NSSSLProfile.ps1
@@ -1,0 +1,197 @@
+<#
+Copyright 2016 Iain Brighton
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+#>
+
+function Set-NSSSLProfile {
+    <#
+    .SYNOPSIS
+        Updates an existing SSL profile.
+
+    .DESCRIPTION
+        Updates an existing SSL profile.
+
+    .PARAMETER Session
+        The NetScaler session object.
+
+    .PARAMETER Name
+        Name of the SSL profile
+
+    .PARAMETER SSL2
+        State of SSLv2 protocol support for the SSL profile.
+
+        Default value: DISABLED
+
+    .PARAMETER SSL3
+        State of SSLv3 protocol support for the SSL profile.
+
+        Default value: ENABLED
+
+    .PARAMETER TLS1
+        State of TLSv1.0 protocol support for the SSL profile.
+
+        Default value: ENABLED
+
+    .PARAMETER TLS11
+        State of TLSv1.1 protocol support for the SSL profile.
+
+        Default value: ENABLED
+
+    .PARAMETER TLS12
+        State of TLSv1.2 protocol support for the SSL profile.
+
+        Default value: ENABLED
+
+    .PARAMETER DenySslRenegotiation
+        Deny renegotiation in specified circumstances.
+
+    .PARAMETER DH
+        State of Diffie-Hellman (DH) key exchange.
+
+        Default value: DISABLED
+
+    .PARAMETER DHFile
+        Name of and, optionally, path to the DH parameter file, in PEM format, to be installed. /nsconfig/ssl/ is the default path.
+
+    .PARAMETER DHCount
+        Number of interactions, between the client and the NetScaler appliance, after which the DH private-public pair is regenerated. A value of zero (0) specifies infinite use (no refresh).
+
+    .PARAMETER DHKeyExpSizeLimit
+        This option enables the use of NIST recommended (NIST Special Publication 800-56A) bit size for private-key size. For example, for DH params of size 2048bit, the private-key size recommended is 224bits. This is rounded-up to 256bits.
+
+        Default value: DISABLED
+
+    .PARAMETER ProfileType
+        Type of profile. Front end profiles apply to the entity that receives requests from a client. Backend profiles apply to the entity that sends client requests to a server.
+
+        Default value: FrontEnd
+
+    .PARAMETER DenySslRenegotiation
+        Deny renegotiation in specified circumstances.
+
+        Default value: All
+
+    .EXAMPLE
+        Set-NSSSLProfile -ProfileName "Secure_SSL_Profile" -SSL3 $false
+
+        Disables the SSLv3 protocol in the SSL profile named "Secure_SSL_Profile"
+
+    .EXAMPLE
+        Set-NSSSLProfile -ProfileName "Secure_SSL_Profile" -DenySslRenegotiation 'ALL' -PassThru
+
+        Disables the SSL renegotiation in the SSL profile named "Secure_SSL_Profile" and returns the updated object.
+
+    .PARAMETER Force
+        Suppress confirmation when updating a SSL profile.
+
+    .PARAMETER Passthru
+        Return the load balancer server object.
+    #>
+    [cmdletbinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
+    param(
+        $Session = $script:session,
+
+        [parameter(Mandatory)]
+        [string]$Name,
+
+        [ValidateSet('NO','FRONTEND_CLIENT','FRONTENT_CLIENTSERVER','ALL','NONSECURE')]
+        [string]$DenySslRenegotiation,
+
+        [ValidateSet('FrontEnd','BackEnd')]
+        [string]$ProfileType,
+
+        [ValidateSet('ENABLED','DISABLED')]
+        [string]$SSL2,
+
+        [ValidateSet('ENABLED','DISABLED')]
+        [string]$SSL3,
+
+        [ValidateSet('ENABLED','DISABLED')]
+        [string]$TLS1,
+
+        [ValidateSet('ENABLED','DISABLED')]
+        [string]$TLS11,
+
+        [ValidateSet('ENABLED','DISABLED')]
+        [string]$TLS12,
+
+        [ValidateSet('ENABLED','DISABLED')]
+        [string]$DH,
+
+        [string]$DHFile,
+
+        [ValidateRange(0,65534)]
+        [int]$DHCount,
+
+        [ValidateSet('ENABLED','DISABLED')]
+        [string]$DHKeyExpSizeLimit,
+
+        [switch]$Force,
+
+        [switch]$PassThru
+    )
+
+    begin {
+        _AssertSessionActive
+    }
+
+    process {
+        if ($Force -or $PSCmdlet.ShouldProcess($Name, 'Edit SSL Profile')) {
+            try {
+                $params = @{
+                    name = $Name
+                }
+                if ($PSBoundParameters.ContainsKey('DenySslRenegotiation')) {
+                    $params.Add('denysslreneg', $DenySslRenegotiation)
+                }
+                if ($PSBoundParameters.ContainsKey('SSL2')) {
+                    $params.Add('ssl2', $SSL2)
+                }
+                if ($PSBoundParameters.ContainsKey('SSL3')) {
+                    $params.Add('ssl3', $SSL3)
+                }
+                if ($PSBoundParameters.ContainsKey('TLS1')) {
+                    $params.Add('tls1', $TLS1)
+                }
+                if ($PSBoundParameters.ContainsKey('TLS11')) {
+                    $params.Add('tls11', $TLS11)
+                }
+                if ($PSBoundParameters.ContainsKey('TLS12')) {
+                    $params.Add('tls12', $TLS12)
+                }
+                if ($PSBoundParameters.ContainsKey('DH')) {
+                    $params.Add('dh', $DH)
+                }
+                if ($PSBoundParameters.ContainsKey('DHFile')) {
+                    $params.Add('dhfile', $DHFile)
+                }
+                if ($PSBoundParameters.ContainsKey('DHCount')) {
+                    $params.Add('dhcount', $DHCount)
+                }
+                if ($PSBoundParameters.ContainsKey('DHKeyExpSizeLimit')) {
+                    $params.Add('dhkeyexpsizelimit', $DHKeyExpSizeLimit)
+                }
+
+                _InvokeNSRestApi -Session $Session -Method PUT -Type sslprofile -Payload $params
+
+                if ($PSBoundParameters.ContainsKey('PassThru')) {
+                    return Get-NSSSLProfile -Session $Session -Name $Name
+                }
+            }
+            catch {
+                throw $_
+            }
+        }
+    }
+}

--- a/NetScaler/Public/Set-NSVPNVirtualServerTheme.ps1
+++ b/NetScaler/Public/Set-NSVPNVirtualServerTheme.ps1
@@ -1,0 +1,90 @@
+<#
+Copyright 2016 Iain Brighton
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+#>
+
+function Set-NSVPNVirtualServerTheme {
+    <#
+    .SYNOPSIS
+        Configures an existing NetScaler virtual server theme.
+
+    .DESCRIPTION
+        Configures an existing NetScaler virtual server theme.
+
+    .EXAMPLE
+        Set-NSVPNVirtualServerTheme -Name 'ag01' -Theme 'X1'
+
+        Sets the'ag01' NetScaler Gateway virtual server's theme to the built-in 'X1' theme.
+
+    .PARAMETER Session
+        The NetScaler session object.
+
+    .PARAMETER Name
+        The name or names of the NetScaler Gateway virtual servers to set.
+
+    .PARAMETER Theme
+        The name of the theme to apply to the NetScaler Gateway virtual server.
+
+    .PARAMETER Force
+        Suppress confirmation when updating a virtual server.
+
+    .PARAMETER Passthru
+        Return the virtual server object.
+
+    .NOTES
+        Requires NetScaler 11.0 or later
+    #>
+    [cmdletbinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
+    param(
+        $Session = $script:session,
+
+        [parameter(Mandatory, ValueFromPipeline, ValueFromPipelineByPropertyName)]
+        [alias('VirtualServerName')]
+        [string[]]$Name,
+
+        [parameter(Mandatory, ValueFromPipelineByPropertyName)]
+        [ValidateSet('Default','GreenBubble','X1')]
+        [string]$Theme,
+
+        [Switch]$Force,
+
+        [Switch]$PassThru
+    )
+
+    begin {
+        _AssertSessionActive
+        _AssertNSVersion -MinimumVersion '11.0'
+    }
+
+    process {
+        foreach ($item in $Name) {
+            if ($Force -or $PSCmdlet.ShouldProcess($item, 'Edit NetScaler Gateway Theme')) {
+                try {
+                    $params = @{
+                        name = $item;
+                        portaltheme = $Theme;
+                    }
+                    _InvokeNSRestApi -Session $Session -Method POST -Type vpnvserver_vpnportaltheme_binding -Payload $params
+
+                    if ($PSBoundParameters.ContainsKey('PassThru')) {
+                        return Get-NSVPNVirtualServerTheme -Session $Session -Name $item
+                    }
+                }
+                catch {
+                    throw $_
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description
Adds 32 additional cmdlets
* Added Get-NSVersion
* Added Get-NSDnsNameServer
* Added Get-NSDnsSuffix, Add-NSDnsSuffix and Remove-NSDnsSuffix
* Added Get-NSSSLCertificateLink, Add-NSSSLCertificateLink and Remove-NSSSLCertificateLink
* Added Get-NSSSLProfile, New-NSSSLProfile, Set-NSSSLProfile and Remove-NSSSLProfile
* Added Add-NSLBServiceGroupMonitorBinding and Remove-NSLBServiceGroupMonitorBinding
* Added Get-NSLBSSLVirtualServerProfile, Set-NSLBSSLVirtualServerProfile and Remove-NSLBSSLVirtualServerProfile
* Added Get-NSLDAPAuthenticationServer, New-NSLDAPAuthenticationServer and Remove-NSLDAPAuthenticationServer
* Added Get-NSLDAPAuthenticationPolicy, New-NSLDAPAuthenticationPolicy and Remove-NSLDAPAuthenticationPolicy
* Added New-NSVPNVirtualServer
* Added Get-NSVPNVirtualServerBinding and Add-NSVPNVirtualServerBinding
* Added Get-NSVPNVirtualServerTheme and Set-NSVPNVirtualServerTheme
* Added New-NSVPNSessionPolicy and Remove-NSVPNSessionPolicy
* Added New-NSVPNSessionProfile and Remove-NSVPNSessionProfile

### Improvements
* Modified Get-NSLBServiceGroupMonitorBinding to support filtering by monitor name
* Added -Force parameter to Add-NSLBSSLVirtualServerCertificateBinding to suppress confirmation
* Added private _AssertNSVersion to enforce particular versioned APIs, e.g. Get-NSVPNVirtualServerTheme

### Bug Fixes
* Fixed _InvokeNSRestApiGet to filter collections
* Fixed bug in Add-NSDnsNameServer where DNSVServerName could not be blank

## Related Issue
Fixes #20

## Motivation and Context
Needed to configure NetScaler Gateways in our dev/test labs.

## How Has This Been Tested?
Manually tested against NetScaler 10.5, 11.0 and 11.1 VPX appliances.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
