### PR TITLE
Adds Get-NSTimeZone and additional help tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
     * Added Get-NSVPNVirtualServerTheme and Set-NSVPNVirtualServerTheme (via @iainbrighton)
     * Added New-NSVPNSessionPolicy and Remove-NSVPNSessionPolicy (via @iainbrighton)
     * Added New-NSVPNSessionProfile and Remove-NSVPNSessionProfile (via @iainbrighton)
+    * Added Get-NSTimeZone (via @iainbrighton)
 
   * Improvements
     * Modified New-NSLBMonitor allow setting HTTP request and expected response codes parameters (via @rokett)
@@ -37,6 +38,8 @@
     * Modified Get-NSLBServiceGroupMonitorBinding to support filtering by monitor name (via @iainbrighton)
     * Added -Force parameter to Add-NSLBSSLVirtualServerCertificateBinding to suppress confirmation (via @iainbrighton)
     * Added private _AssertNSVersion to enforce particular versioned APIs, e.g. Get-NSVPNVirtualServerTheme (via @iainbrighton)
+    * Modified Set-NSTimeZone to accept pipeline input and return just the configured timezone (via @iainbrighton)
+    * Added additional help tests and fixed incorrect help examples/commands (via @iainbrighton)
 
   * Bug fixes
     * Fixed bug in Add-NSLBVirtualServerBinding where weight was improperly being added when binding to a service group. (via @rokett)

--- a/NetScaler/NetScaler.psd1
+++ b/NetScaler/NetScaler.psd1
@@ -138,6 +138,7 @@ FunctionsToExport = @(
     'Get-NSSSLCertificateLink',
     'Get-NSSSLProfile',
     'Get-NSSystemFile',
+    'Get-NSTimeZone',
     'Get-NSVersion',
     'Get-NSVPNServer',
     'Get-NSVPNSessionPolicy',

--- a/NetScaler/Public/Disconnect-NetScaler.ps1
+++ b/NetScaler/Public/Disconnect-NetScaler.ps1
@@ -23,12 +23,12 @@ function Disconnect-NetScaler {
         Disconnect session with NetScaler.
 
     .EXAMPLE
-        Disconnet-NetScaler
+        Disconnect-NetScaler
 
         Disconnect from default NetScaler session.
 
     .EXAMPLE
-        Disconnet-NetScaler -Session $session
+        Disconnect-NetScaler -Session $session
 
         Disconnect from specific NetScaler session object $session.
 

--- a/NetScaler/Public/Get-NSLBVirtualServerBinding.ps1
+++ b/NetScaler/Public/Get-NSLBVirtualServerBinding.ps1
@@ -23,14 +23,14 @@ function Get-NSLBVirtualServerBinding {
         Gets the specified load balancer virtual server binding object.
 
     .EXAMPLE
-        Get-NSLBVirtualServer
+        Get-NSLBVirtualServerBinding
 
-        Get all load balancer virtual server objects.
+        Get all load balancer virtual server binding objects.
 
     .EXAMPLE
-        Get-NSLBVirtualServer -Name 'vserver01'
-    
-        Get the load balancer virtual server named 'vserver01'.
+        Get-NSLBVirtualServerBinding -Name 'vserver01'
+
+        Get the load balancer virtual server binding object for the 'vserver01' load balancing virtual server.
 
     .PARAMETER Session
         The NetScaler session object.

--- a/NetScaler/Public/Get-NSResponderAction.ps1
+++ b/NetScaler/Public/Get-NSResponderAction.ps1
@@ -28,13 +28,13 @@ function Get-NSResponderAction {
         Get all responder action objects
 
     .EXAMPLE
-        Get-NSReponderAction -Name 'act-redirect'
-    
+        Get-NSResponderAction -Name 'act-redirect'
+
         Get the responder action named act-redirect.
 
     .EXAMPLE
-        Get-NSReponderAction -Name /redir/
-    
+        Get-NSResponderAction -Name /redir/
+
         Get all the responder actions whose name matches '.*redir.*' (NS treats this as a regex).
 
     .PARAMETER Session
@@ -42,7 +42,7 @@ function Get-NSResponderAction {
 
     .PARAMETER Name
         A filter to apply to the responder action name value.
-        
+
     .PARAMETER Type
         A filter to apply to the responder action type value.
 
@@ -57,10 +57,10 @@ function Get-NSResponderAction {
 
     .PARAMETER Hits
         A filter to apply to the responder action hits value.
-        
+
     .PARAMETER UndefHits
         A filter to apply to the responder action undefined hits value.
-        
+
     .PARAMETER ReferenceCount
         A filter to apply to the responder action reference count value.
 
@@ -78,9 +78,9 @@ function Get-NSResponderAction {
         [string]$Target,
 
         [string]$HtmlPage,
-        
+
         [string]$ResponseStatusCode,
-        
+
         [string]$Hits,
 
         [Alias('UndefinedHits')]
@@ -100,7 +100,7 @@ function Get-NSResponderAction {
         "Name","Type","Target","HtmlPage","ResponseStatusCode","Hits","UndefHits","ReferenceCount" | ForEach {
             if ($PSBoundParameters.ContainsKey($_)) {
                 $filters[$_.ToLower()] = (Get-Variable -Name $_).Value
-            }            
+            }
         }
 
         $response = _InvokeNSRestApi -Session $Session -Method Get -Type responderaction -Action Get -Filters $filters

--- a/NetScaler/Public/Get-NSTimeZone.ps1
+++ b/NetScaler/Public/Get-NSTimeZone.ps1
@@ -1,0 +1,51 @@
+<#
+Copyright 2016 Iain Brighton
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+#>
+
+function Get-NSTimeZone {
+    <#
+    .SYNOPSIS
+        Gets the NetScaler's timezone.
+
+    .DESCRIPTION
+        Gets the NetScaler's timezone.
+
+    .EXAMPLE
+        Get-NSTimeZone -Session $session
+
+        Returns the configured timezone.
+
+    .PARAMETER Session
+        The NetScaler session object.
+    #>
+    [cmdletbinding()]
+    param(
+        $Session = $Script:Session
+    )
+
+    begin {
+        _AssertSessionActive
+    }
+
+    process {
+        try {
+            $config = _InvokeNSRestApi -Session $Session -Method GET -Type nsconfig -Action get
+            return $config.nsconfig.timezone
+        }
+        catch {
+            throw $_
+        }
+    }
+}

--- a/NetScaler/Public/New-NSKCDAccount.ps1
+++ b/NetScaler/Public/New-NSKCDAccount.ps1
@@ -24,34 +24,34 @@ function New-NSKCDAccount {
 
     .EXAMPLE
         $cred = Get-Credential
-        New-KCDAccount -Name ns_svc -Realm LAB -DelegatedUser ns_svc -Credential $cred
-        
+        New-NSKCDAccount -Name ns_svc -Realm LAB -DelegatedUser ns_svc -Credential $cred
+
         Create a new KCD account with the given delegated user.
 
     .PARAMETER Session
         The NetScaler session object.
 
     .PARAMETER Name
-        Name for the server. 
-    
-        Must begin with an ASCII alphabetic or underscore (_) character, and must contain only 
-        ASCII alphanumeric, underscore, hash (#), period (.), space, colon (:), at (@), equals (=), 
+        Name for the server.
+
+        Must begin with an ASCII alphabetic or underscore (_) character, and must contain only
+        ASCII alphanumeric, underscore, hash (#), period (.), space, colon (:), at (@), equals (=),
         and hyphen (-) characters. Can be changed after the name is created.
-        
+
         Minimum length = 1
 
     .PARAMETER Realm
         Kerberos realm the delegation occurs in.
-    
+
     .PARAMETER Credential
         Credential holding delegated username and password.
 
     .PARAMETER Passthru
         Return the load balancer server object.
-        
+
     .NOTES
         Nitro implementation status: partial
-        
+
     #>
     [cmdletbinding(SupportsShouldProcess = $true, ConfirmImpact='Low')]
     param(
@@ -64,7 +64,7 @@ function New-NSKCDAccount {
         [String]$Realm,
 
         [parameter(Mandatory = $true)]
-        [pscredential]$Credential,      
+        [pscredential]$Credential,
 
         [Switch]$PassThru
     )

--- a/NetScaler/Public/New-NSNTPServer.ps1
+++ b/NetScaler/Public/New-NSNTPServer.ps1
@@ -23,34 +23,34 @@ function New-NSNTPServer {
         Creates a new NTP server.
 
     .EXAMPLE
-        New-NTPServer -Server 1.2.3.4
-        
+        New-NSNTPServer -Server 1.2.3.4
+
         Create a new KCD account with the given delegate user.
 
     .PARAMETER Session
         The NetScaler session object.
 
     .PARAMETER Server
-        IP address (or array of addresses) of the NTP server(s). 
-    
+        IP address (or array of addresses) of the NTP server(s).
+
     .PARAMETER MinPollInterval
         Minimum poll interval: minimum time after which Netscaler must poll the NTP server.
         Expressed power of 2 seconds.
-        
+
         Default value: 6 (64 seconds)
 
     .PARAMETER MaxPollInterval
         Maximum poll interval: maximum time after which Netscaler must poll the NTP server.
         Expressed power of 2 seconds.
-        
+
         Default value: 10 (1024 seconds)
 
     .PARAMETER Passthru
         Return the load balancer server object.
-        
+
     .NOTES
         Nitro implementation status: partial
-    
+
     #>
     [cmdletbinding(SupportsShouldProcess = $true, ConfirmImpact='Low')]
     param(

--- a/NetScaler/Public/Set-NSLBServiceGroup.ps1
+++ b/NetScaler/Public/Set-NSLBServiceGroup.ps1
@@ -29,12 +29,12 @@ function Set-NSLBServiceGroup {
 
     .EXAMPLE
         Set-NSLBServiceGroup -Name 'sg01' HTTPCompression = 'ON'
-    
+
         Enable the HTTP compression feature for service group 'sg01'.
 
     .EXAMPLE
-        Set-NSLBVirtualServer -Name 'sg01' MaxBandwithKbps 819200
-    
+        Set-NSLBServiceGroup -Name 'sg01' MaxBandwithKbps 819200
+
         Set the maximum bandwidth for service group 'sg01' to 819200 Kbps.
 
     .PARAMETER Session
@@ -65,7 +65,7 @@ function Set-NSLBServiceGroup {
         Use the proxy port as the source port when initiating connections with the server.
 
     .PARAMETER DownStateFlush
-        Flush all active transactions associated with all the services in the service group whose state transitions from UP to DOWN. 
+        Flush all active transactions associated with all the services in the service group whose state transitions from UP to DOWN.
 
     .PARAMETER UseClientIP
         Use client's IP address as the source IP address when initiating connection to the server.

--- a/NetScaler/Public/Set-NSResponderAction.ps1
+++ b/NetScaler/Public/Set-NSResponderAction.ps1
@@ -23,13 +23,13 @@ function Set-NSResponderAction {
         Updates an existing responder action.
 
     .EXAMPLE
-        Set-ResponderAction -Name 'act-redirect' -Target '"/test"'
+        Set-NSResponderAction -Name 'act-redirect' -Target '"/test"'
 
         Sets the target (expression) for responder action 'act-redirect' to /test.
 
     .EXAMPLE
-        Set-ResponderAction -Name 'act-redirect' -Comment 'this is a comment' -PassThru
-    
+        Set-NSResponderAction -Name 'act-redirect' -Comment 'this is a comment' -PassThru
+
         Sets the comment for responder action 'act-redirect' and returns the updated object.
 
     .PARAMETER Session
@@ -45,7 +45,7 @@ function Set-NSResponderAction {
     .PARAMETER ResponseStatusCode
         The HTTP response status code returned by the responder action.
         Valid only for types Redirect, RespondWith, RespondWithSQLOK and RespondWithSQLError.
-        
+
         Range: 100 - 599
 
     .PARAMETER ReasonPhrase
@@ -57,7 +57,7 @@ function Set-NSResponderAction {
 
     .PARAMETER HtmlPage
         The name of the HTML page to respond with.
-        
+
         Valid only for type RespondWithHTMLPage.
 
     .PARAMETER Comment
@@ -106,13 +106,13 @@ function Set-NSResponderAction {
                 }
                 if ($PSBoundParameters.ContainsKey('Target')) {
                     $params.Add('target', $Target)
-                }                            
+                }
                 if ($PSBoundParameters.ContainsKey('ResponseStatusCode')) {
                     $params.Add('responsestatuscode', $ResponseStatusCode)
                 }
                 if ($PSBoundParameters.ContainsKey('ReasonPhrase')) {
                     $params.Add('reasonphrase', $ReasonPhrase)
-                }                            
+                }
                 if ($PSBoundParameters.ContainsKey('HtmlPage')) {
                     $params.Add('htmlpage', $HtmlPage)
                 }

--- a/NetScaler/Public/Set-NSTimeZone.ps1
+++ b/NetScaler/Public/Set-NSTimeZone.ps1
@@ -45,14 +45,14 @@ function Set-NSTimeZone {
         Suppress confirmation when updating the timezone.
 
     .PARAMETER Passthru
-        Return the hostname.
+        Return the configured timezone.
     #>
     [cmdletbinding(SupportsShouldProcess = $true, ConfirmImpact='high')]
     param(
-        [parameter(Mandatory)]
+        [parameter()]
         $Session = $script:session,
 
-        [parameter(Mandatory)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [ValidateScript({
             if ($NSTimeZones -contains $_) {
                 $true
@@ -80,8 +80,7 @@ function Set-NSTimeZone {
             _InvokeNSRestApi -Session $Session -Method PUT -Type nsconfig -Payload $params
 
             if ($PSBoundParameters.ContainsKey('PassThru')) {
-                $config = _InvokeNSRestApi -Session $Session -Method GET -Type nsconfig -Action get
-                return $config.nsconfig
+                return Get-NSTimeZone -Session $Session
             }
         }
     }

--- a/Tests/Meta/Help.tests.ps1
+++ b/Tests/Meta/Help.tests.ps1
@@ -29,14 +29,33 @@ foreach ($command in $commands) {
             $help.Description | Should Not BeNullOrEmpty
         }
 
-        # Should be at least one example
-        It "gets example code from $commandName" {
-            ($help.Examples.Example | Select-Object -First 1).Code | Should Not BeNullOrEmpty
-        }
+        Context "Test example help for $commandName" {
 
-        # Should be at least one example description
-        It "gets example remarks from $commandName" {
-            ($help.Examples.Example.Remarks | Select-Object -First 1).Text | Should Not BeNullOrEmpty
+            $examples = @($help.examples.example)
+
+            # Should be at least one example
+            It "$commandName contains at least one examplegets example code from $commandName" {
+                $examples.Count -ge 1 | Should Be $true
+            }
+
+            for ($i = 0; $i -lt $examples.Count; $i++) {
+
+                $example = $examples[$i]
+
+                It "gets example $i code from $commandName" {
+                    $example.Code | Should Not BeNullOrEmpty
+                }
+
+                It "gets example $i remarks from $commandName" {
+                    $example.Remarks | Should Not BeNullOrEmpty
+                }
+
+                It "example $i code contains command $commandName" {
+                    ## Command may be on the second line (within the remarks) so concatenate them
+                    $example.Code + $example.remarks.Text | Should Match $commandName
+                }
+            }
+
         }
 
         Context "Test parameter help for $commandName" {
@@ -83,13 +102,13 @@ foreach ($command in $commands) {
             }
         }
 
-        Context "Help Links should be Valid for $commandName" {            
+        Context "Help Links should be Valid for $commandName" {
             $link = $help.relatedLinks.navigationLink.uri
-        
+
             foreach ($link in $links) {
                 if ($link) {
                     # Should have a valid uri if one is provided.
-                    it "[$link] should have 200 Status Code for $commandName" {        
+                    it "[$link] should have 200 Status Code for $commandName" {
                         $Results = Invoke-WebRequest -Uri $link -UseBasicParsing
                         $Results.StatusCode | Should Be '200'
                     }


### PR DESCRIPTION
## Description
* Adds additional Help tests to ensure the correct command names are used in the examples
* Fixed incorrect help command names in example help
* Adds Get-NSTimeZone
* Updates Set-NSTimeZone to accept pipeline input and return just the TimeZone. __This might be classified as breaking change as the output has changed?__

## How Has This Been Tested?
Manually tested on NetScaler 11.0 and 11.1

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
