### PR TITLE
Typo in Add-NSLBVirtualServerBinding and refactoring of Get-NSSystemFile

### DIFF
--- a/Contrib/New-GetCmdlet.ps1
+++ b/Contrib/New-GetCmdlet.ps1
@@ -8,7 +8,9 @@ Param(
     [Parameter(Mandatory)]
     [String]$Label,
     
-    [Hashtable]$Filters = $Null
+    [Hashtable]$Filters = $Null,
+
+    [Switch]$Arguments = $False
 )
     $ErrorActionPreference = "Stop"
     
@@ -50,11 +52,13 @@ Param(
 
 
 if ($Filters -and ($Filters.Count -ne 0)) {
+    $ArgumentName = "-Filters"
+    if ($Arguments) { $ArgumentName = "-Arguments" }
     $ProcessBlock = @"
         # Contruct a filter hash if we specified any filters
         `$Filters = @{}
 $(($Filters.GetEnumerator() | % { Expand-Filter $_.Key $_.Value }) -Join "`n")
-        _InvokeNSRestApiGet -Session `$Session -Type $Type -Name `$Name -Filters `$Filters
+        _InvokeNSRestApiGet -Session `$Session -Type $Type -Name `$Name $ArgumentName `$Filters
 "@
     $FilterParameters = ",`n`n" + (
         ($Filters.GetEnumerator() | % { Expand-FilterParam $_.Key $_.Value }) -Join ",`n`n"

--- a/Contrib/New-GetCmdlets.ps1
+++ b/Contrib/New-GetCmdlets.ps1
@@ -4,7 +4,7 @@
 
 # Format: @(<cmdlet name>, <resource type>, <documentation label>,
 #            <optional hashtable of parameter names to a hashtable of filter name to parameter label>
-#         )
+#         ), <optional boolean that indicates arguments instead of filters>
 
 @(
     @("CSAction",                              "csaction",                          "content switching action",
@@ -156,13 +156,19 @@
         [ordered]@{
             "FileLocation"          = @("filelocation", "file location") 
             "Filename"              = @("filename", "file name")
-        }
-    )    
+        }, $True
+    )
+    # The following Get cmdlet has been modified after generation!
+    #@("VirtualServerCertificateBinding",   "sslvserver_sslcertkey_binding",      "virtual server certificate-key pair binding"
+    #    [ordered]@{}
+    #)  
+      
     #@("LBVirtualServerResponderPolicyBinding", "lbvserver_responderpolicy_binding", "load balancer server responder policy binding"),
     #@("LBVirtualServerRewritePolicyBinding",   "lbvserver_rewritepolicy_binding",   "load balancer server rewrite policy binding")
-) | % {    
-    echo "Get-NS$($_[0]) | Measure"
-    Contrib\New-GetCmdlet -Name $_[0] -Type $_[1] -Label $_[2] -Filters $_[3]
+) | % {
+    $Name, $Type, $Label, $Filters, $Arguments = $_
+    echo "Get-NS$($Name) | Measure -Count"
+    Contrib\New-GetCmdlet -Name $Name -Type $Type -Label $Label -Filters $Filters -Arguments:$Arguments
 }
 
 

--- a/NetScaler/Private/_InvokeNSRestApiGet.ps1
+++ b/NetScaler/Private/_InvokeNSRestApiGet.ps1
@@ -18,10 +18,15 @@ function _InvokeNSRestApiGet {
     .PARAMETER Filters
         A Hashtable of search filter values.
 
-    .EXAMPLE
-        TODO
+    .PARAMETER Arguments
+        A Hashtable of arguments values.
 
-    .OUTPUTS
+    .EXAMPLE
+        _InvokeNSRestApiGet -Session $Session -Type csaction -Name "ACT-rewrite-host"
+
+        Retrieves the csaction named 'ACT-rewrite-host'.
+        
+    .OUTPUTS        
         PSCustomObject that represents the JSON response content. This object can be manipulated using the ConvertTo-Json Cmdlet.
     #>
     [CmdletBinding()]
@@ -33,8 +38,10 @@ function _InvokeNSRestApiGet {
         [string[]]$Name = @(),
 
         [string]$Type,
-
-        [Hashtable]$Filters = @{}
+        
+        [Hashtable]$Filters = @{},
+        
+        [Hashtable]$Arguments = @{}
     )
 
     if ($Name.Count -gt 0) {
@@ -46,7 +53,7 @@ function _InvokeNSRestApiGet {
             }
         }
     } else {
-        $response = _InvokeNSRestApi -Session $Session -Method Get -Type $Type -Action Get -Filters $Filters
+        $response = _InvokeNSRestApi -Session $Session -Method Get -Type $Type -Action Get -Filters $Filters -Arguments $Arguments
         if ($response.errorcode -ne 0) { throw $response }
         if ($Response.psobject.properties.name -contains $Type) {
             $response.$Type

--- a/NetScaler/Public/Add-NSLBVirtualServerBinding.ps1
+++ b/NetScaler/Public/Add-NSLBVirtualServerBinding.ps1
@@ -61,7 +61,7 @@ function Add-NSLBVirtualServerBinding {
         Suppress confirmation when binding the service group to the virtual server.
 
     .PARAMETER Passthru
-        Return the load balancer server object.
+        Return the binding object.
     #>
     [cmdletbinding(SupportsShouldProcess = $true, ConfirmImpact='Medium', DefaultParameterSetName='servicegroup')]
     param(

--- a/NetScaler/Public/Get-NSSystemFile.ps1
+++ b/NetScaler/Public/Get-NSSystemFile.ps1
@@ -77,10 +77,6 @@ function Get-NSSystemFile {
         if ($PSBoundParameters.ContainsKey('FileLocation')) {
             $Filters['filelocation'] = $FileLocation
         }
-        $response = _InvokeNSRestApi -Session $Session -Method GET -Type systemfile -Arguments $Filters
-        if ($response.errorcode -ne 0) { throw $response }
-        if ($response.psobject.properties | where name -eq systemfile) {
-            return $response.systemfile
-        }
+        _InvokeNSRestApiGet -Session $Session -Type systemfile -Name $Name -Arguments $Filters
     }
 }


### PR DESCRIPTION
Typo in Add-NSLBVirtualServerBinding and refactoring of Get-NSSystemFile

## Refactoring 
* Refactored Get-NSSystemFile to use _InvokeNSRestApiGet
* Support for -Argument in _InvokeNsRestApiGet and generator

## Bugs
* Error in Add-NSLBVirtualServerBinding comment

## Related Issue


## Motivation and Context
These additions and changes were required in my own production environment for specific things I needed to do. They are also the basis of upcoming changes.

## How Has This Been Tested?

Tested by using the new and changed functions. All appears to be working as expected.

## Types of changes
- [x ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Remark: tests are passing except for :

        [-] changelog and manifest versions are the same 13ms
        Expected: {1.3.0}
        But was:  {1.4.0}
        64:             $script:changelogVersion -as [Version] | Should be ( $script:manifest.Version -as [Version] )
        at <ScriptBlock>, C:\vagrant\Tests\meta\Manifest.Tests.ps1: line 64

but the same test fails on the "dev" branch.