### PR TITLE
Do not extract unreleased versions from CHANGELOG.md

### DIFF
--- a/Tests/Meta/Manifest.Tests.ps1
+++ b/Tests/Meta/Manifest.Tests.ps1
@@ -51,7 +51,7 @@ Describe 'Module manifest' {
         $script:changelogVersion = $null
         It "has a valid version in the changelog" {
             foreach ($line in (Get-Content $changelogPath)) {
-                if ($line -match "^\D*(?<Version>(\d+\.){1,3}\d+)") {
+                if ($line -match "^## (?<Version>(\d+\.){1,3}\d+) \(\d{4}-\d{2}-\d{2}\)") {
                     $script:changelogVersion = $matches.Version
                     break
                 }


### PR DESCRIPTION
Corrects issue #41 (test fails on unreleased version number in CHANGELO.md)

## Description
Made the regex that extracts version numbers from the CHANGELOG more restrictive:

    ## 1.2.3 (2016-01-01)

is considered a release

    ## 1.2.3 (Unreleased)

is not.

## Related Issue

#41 

## Motivation and Context
The unit tests will work again.

## How Has This Been Tested?
Tests work on my local copy. Appveyor should go back to green.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
