### PR TITLE
Add Get-NSStat function to retrieve any type of NetScaler stat object 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
     * Added parameters to New-NSLBVirtualServer to configure a redirect (via @rokett)
     * Added parameter 'ICMPVSResponse' to New-NSLBVirtualServer which controler whether ICMP response is ACTIVE or PASSIVE on VIP (via @dbroeglin)
     * Added Add-NSLBVirtualServerResponderPolicyBinding an Get-NSLBVirtualServerResponderPolicyBinding (via @rokett)
+    * Added Get-NSStat function to get NetScaler stat objects (via @devblackops)
 
   * Improvements
     * Added support for 'Arguments' parameter in _InvokeNsRestApiGet (via @dbroeglin)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 
   * Bug fixes
     * Fix typo in Add-NSLBVirtualServerBinding (via @rokett)
+
+  * Deprecated
+    * Mark Get-NSLBStat as deprecated in favor of Get-NSStat
   
 ## 1.3.0 (2016-09-10)
   * Features

--- a/NetScaler/NetScaler.psd1
+++ b/NetScaler/NetScaler.psd1
@@ -132,6 +132,7 @@ FunctionsToExport = @(
     'Get-NSResponderPolicy',
     'Get-NSRewriteAction',
     'Get-NSRewritePolicy',
+    'Get-NSStat',
     'Get-NSMode',
     'Get-NSNTPServer',
     'Get-NSSAMLAuthenticationPolicy',

--- a/NetScaler/Public/Get-NSLBStat.ps1
+++ b/NetScaler/Public/Get-NSLBStat.ps1
@@ -49,6 +49,8 @@ function Get-NSLBStat {
     begin {
         _AssertSessionActive
         $stats = @()
+
+        Write-Warning -Message 'This function is deprecated in favor of Get-NSStat and will be removed in a future major release. Please use Get-NSStat -Type <typename> instead.'
     }
 
     process {

--- a/NetScaler/Public/Get-NSStat.ps1
+++ b/NetScaler/Public/Get-NSStat.ps1
@@ -1,0 +1,89 @@
+<#
+Copyright 2015 Brandon Olin
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+#>
+
+function Get-NSStat {
+    <#
+    .SYNOPSIS
+        Gets the specified stat object.
+
+    .DESCRIPTION
+        Gets the specified stat object.
+
+    .EXAMPLE
+        Get-NSStat -Type 'lbvserver'
+
+        Get all stats of type lbvserver
+
+    .EXAMPLE
+        Get-NSStat -Type 'servicegroup' -Name 'sg01'
+
+        Get the stats for service group with name sg01
+
+    .PARAMETER Session
+        The NetScaler session object.
+
+    .PARAMETER Type
+        The type of stat object to retrieve
+
+    .PARAMETER Name
+        The name or names of specific stat objects to retrieve
+    #>
+    [cmdletbinding()]
+    param(
+        $Session = $script:session,
+
+        [ValidateSet('aaa', 'appflow', 'appfw', 'appfwpolicy', 'appfwpolicylabel', 'appfwprofile', 'appqoe', 'appqoepolicy',
+            'audit', 'authenticationloginschemapolicy', 'authenticationpolicy', 'authenticationpolicylabel', 'authenticationsamlidpolicy',
+            'authenticationvserver', 'authorizationpolicylabel', 'autoscalepolicy', 'service', 'servicegroup', 'servicegroupmember',
+            'ca', 'cache', 'cachecontentgroup', 'cachepolicy', 'cachepolicylabel', 'clusterinstance', 'clusternode', 'cmp', 'cmppolicy',
+            'cmppolicylabel', 'crvserver', 'cvserver', 'dns', 'dnspolicylabel', 'dnsrecords', 'dos', 'dospolicy', 'feo', 'gslbdomain', 'gslbservice',
+            'gslbsite', 'dslbvserver', 'hanode', 'icapolicy', 'ipseccounters', 'lbvserver', 'lldp', 'lsn', 'lsndslite', 'lsngroup', 'lsnnat64',
+            'mediaclassification', 'interface', 'bridge', 'inat', 'inatsession', 'nat64', 'rnat', 'rnatip', 'tunnelip', 'tunnelip6', 'vlan', 'vpath',
+            'vxlan', 'ns', 'nsacl', 'nsacl6', 'nslimitidentifier', 'nsmemory', 'nspartition', 'nspbr', 'nssimpleacl', 'nssimpleacl6',
+            'nstrafficdomain', 'pq', 'pqpolicy', 'protocolhttp', 'protocolicmp', 'protocolicmpv6', 'protocolip', 'protocolipv6', 'protocoltcp',
+            'ptotocoludp', 'qos', 'rewritepolicy', 'rewritepolicylabel', 'responderpolicy', 'responderpolicylabel', 'sc', 'scpolicy', 'snmp',
+            'spilloverpolicy', 'ssl', 'sslvserver', 'streamidentifier', 'system', 'systembw', 'systemcpu', 'systemmemory', 'tmsessionpolicy',
+            'tmtrafficpolicy', 'transformpolicy', 'transformpolicylabel', 'vpn', 'vpnvserver', 'pcpserver')]
+        [parameter(Mandatory, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [string[]]$Type,
+
+        [parameter(ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [string[]]$Name = @()
+    )
+
+    begin {
+        _AssertSessionActive
+        $stats = @()
+    }
+
+    process {
+        foreach ($statType in $Type) {
+            if ($Name.Count -gt 0) {
+                foreach ($item in $Name) {
+                    $stats = _InvokeNSRestApi -Session $Session -Method Get -Type $statType -Stat -Resource $item
+                    if ($stats | Get-Member -MemberType NoteProperty | Where Name -eq $statType) {
+                        $stats.$statType
+                    }
+                }
+            } else {
+                $stats = _InvokeNSRestApi -Session $Session -Method Get -Type $statType -Stat
+                if ($stats | Get-Member -MemberType NoteProperty | Where Name -eq $statType) {
+                    $stats.$statType
+                }
+            }
+        }
+    }
+}

--- a/psake.ps1
+++ b/psake.ps1
@@ -4,11 +4,11 @@ properties {
         $projectRoot = $PSScriptRoot
     }
 
-    $sut = "$projectRoot\NetScaler"
-    $metaTests = "$projectRoot\Tests\meta"
-    $unitTests = "$projectRoot\Tests\unit"
-    $integrationTests = "$projectRoot\Tests\integration"
-    $tests = "$projectRoot\Tests"
+    $sut = Join-Path -Path $projectRoot -ChildPath $ENV:BHProjectName
+    $testDir = Join-Path $projectRoot -ChildPath 'Tests'
+    $metaTests = Join-Path $testDir -ChildPath 'Meta'
+    $unitTests = Join-Path $testDir -ChildPath 'Unit'
+    $integrationTests = Join-Path $testDir -ChildPath 'Integration'
 
     $psVersion = $PSVersionTable.PSVersion.Major
 }
@@ -20,14 +20,12 @@ task Init {
     "Build System Details:"
     Get-Item ENV:BH*
 
-    $modules = 'Pester', 'PSDeploy', 'PSScriptAnalyzer'
-    Install-Module $modules -Confirm:$false
-    Import-Module $modules -Verbose:$false -Force
+    Write-Host $sut
 }
 
 task Test -Depends Init, Analyze, Pester-Meta, Pester-Module
 
-task Analyze -Depends Init {
+task Analyze -Depends Init { 
     $saResults = Invoke-ScriptAnalyzer -Path $sut -Severity Error -Recurse -Verbose:$false
     if ($saResults) {
         $saResults | Format-Table


### PR DESCRIPTION
## Description
Adds new function Get-NSStat to retrieve any type of stat object from the NetScaler. A mandatory parameter `-Type` is used to specify the type of stat object to retrieve. An optional parameter `-Name` can be given to retrieve a specific instance of the object type.

Marks Get-NSLBStat as deprecated in favor of Get-NSStat.

## Related Issue
#45 

## Motivation and Context
Add common function to retrieve NetScaler stats.

## How Has This Been Tested?
Ran Get-NSStat using various `-Type` values and observed results.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
