### PR TITLE
Use cmdlets instead of aliases in tests

### DIFF
--- a/Tests/Meta/Help.tests.ps1
+++ b/Tests/Meta/Help.tests.ps1
@@ -67,7 +67,7 @@ foreach ($command in $commands) {
             $parameterNames = $parameters.Name
 
             ## Without the filter, WhatIf and Confirm parameters are still flagged in "finds help parameter in code" test
-            $helpParameters = $help.Parameters.Parameter | Where-Object { $_.Name -notin $common } | Sort -Property Name -Unique
+            $helpParameters = $help.Parameters.Parameter | Where-Object { $_.Name -notin $common } | Sort-Object -Property Name -Unique
             $helpParameterNames = $helpParameters.Name
 
             foreach ($parameter in $parameters) {

--- a/Tests/Meta/MetaFixers.psm1
+++ b/Tests/Meta/MetaFixers.psm1
@@ -47,7 +47,7 @@ function Get-TextFilesList
         [Parameter(Mandatory=$true)]
         [string]$root
     )
-    ls -File -Recurse $root | ? { @('.gitignore', '.gitattributes', '.ps1', '.psm1', '.psd1', '.json', '.xml', '.cmd', '.mof') -contains $_.Extension } 
+    Get-ChildItem -File -Recurse $root | ? { @('.gitignore', '.gitattributes', '.ps1', '.psm1', '.psd1', '.json', '.xml', '.cmd', '.mof') -contains $_.Extension } 
 }
 
 function Test-FileUnicode


### PR DESCRIPTION
Fixes #53 (Test fail because sort and ls aliases are used in Tests)

## Description
Replaced calls to aliases by there respective cmdlets

## Related Issue
#53 

## Motivation and Context
Fixes the tests on MacOSX PSCore

## How Has This Been Tested?

Reran the tests on MacOSX: 
```
Invoke-Pester
```
and Windows 2016:
```
. .\build.ps1 -Task Test
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
