### PR TITLE
Fixing Add-NSCertKeyPair on PS v 6.0

### DIFF
--- a/NetScaler/Public/Add-NSCertKeyPair.ps1
+++ b/NetScaler/Public/Add-NSCertKeyPair.ps1
@@ -104,8 +104,8 @@ function Add-NSCertKeyPair {
                     $params.Add('key', $KeyPath)
                 }
                 if (($CertKeyFormat -in 'PEM','PFX') -and $Password) {
-                    $bstr = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($Password)
-                    $unsecurePassword = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto($bstr)
+                    $creds = [System.Management.Automation.PSCredential]::new("dummy", $Password)
+                    $unsecurePassword = $creds.GetNetworkCredential().Password
                     $params.Add("passplain",$unsecurePassword)
                 }
                 $response = _InvokeNSRestApi  -Session $Session -Method POST -Type sslcertkey -Payload $params -Action add


### PR DESCRIPTION
## Description

`SecureStringToBSTR` seems to be absent of either PS v6.0 or more specifically PS v6.0 on MacOSX.

Replaced usage of SecureStringToBSTR with usage of PSCredential.GetNetworkCredential() which seems a more common way of getting the clear text password out of a SecureString anyway.

## Related Issue
#67 

## Motivation and Context
Add-NSCertKeyPair now works on both on PS v6. It should continue to work fine on other versions too.

## How Has This Been Tested?
Tested in my local lab (NS 11.1 48.10).
See https://github.com/dbroeglin/windows-lab

On PS v6.0 MacOSX and PS v5.1 on Windows Server 2016

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
