### PR TITLE
Fixed URI protocol/scheme scope (and added integration tests)

### DIFF
--- a/ITTests/Simple.ITTests.ps1
+++ b/ITTests/Simple.ITTests.ps1
@@ -1,44 +1,35 @@
-$Nsip              = "172.16.124.11"
-$Username          = "nsroot"
-$Password          = "nsroot"
-
 Import-Module Pester
 
 $here = Split-Path -Parent $MyInvocation.MyCommand.Path
-Import-Module -Force $here\..\Netscaler
+Import-Module -Force $here\..\Netscaler\Netscaler.psd1
 . $here\TestSupport.ps1
 
+Describe "Netscaler Connection" {
+    Context "not connected" {
+        It "should disconnect implicit session" {
+            $Session = Connect-TestNetscaler
+
+            Get-NSHostname
+            Disconnect-Netscaler
+            { Get-NSHostname } | Should Throw "401 (Unauthorized)"
+        }
+
+        It "should disconnect explicit session" {
+            $Session = Connect-TestNetscaler
+
+            Get-NSHostname -Session $Session
+            Disconnect-Netscaler -Session $Session
+            { Get-NSHostname -Session $Session } | Should Throw "401 (Unauthorized)"
+        }
+    }
+
+    Context "connection" {
+    }
+}
+
 Describe "Netscaler Get-*" {
-    $Session = Connect-Netscaler -Hostname $Nsip -Credential $Credential -PassThru
+    $Session = Connect-TestNetscaler
 
-    It "should list VPN policies" {
-        $Policy = Get-NSVPNSessionPolicy
-        
-        $Policy | Should Not BeNullOrEmpty
-        $Policy.name | Should Be "SETVPNPARAMS_POL" 
-    }
-
-    It "should get VPN policy" {
-        $Policy = Get-NSVPNSessionPolicy -Name "SETVPNPARAMS_POL"
-        
-        $Policy | Should Not BeNullOrEmpty
-        $Policy.name | Should Be "SETVPNPARAMS_POL"
-    }
-
-    It "should list VPN profiles" {
-        $Policy = Get-NSVPNSessionProfile
-        
-        $Policy | Should Not BeNullOrEmpty
-        $Policy.name | Should Be "SETVPNPARAMS_ACT" 
-    }
-
-    It "should get VPN profiles" {
-        $Policy = Get-NSVPNSessionProfile -Name "SETVPNPARAMS_ACT"
-        
-        $Policy | Should Not BeNullOrEmpty
-        $Policy.name | Should Be "SETVPNPARAMS_ACT"
-    }
-    
     It "should get a certificate" {
         $Cert = Get-NSSSLCertificate -Name "ns-server-certificate"
 
@@ -50,44 +41,29 @@ Describe "Netscaler Get-*" {
         $Cert = Get-NSSSLCertificate
 
         $Cert | Should Not BeNullOrEmpty
-        $Cert.certkey | Should Be "ns-server-certificate"
-    }
-    
-    It "should list builtin responder policies" {
-        $Result = Get-NSResponderPolicy -ShowBuiltin
-        
-        $Result | Should Not BeNullOrEmpty
-        # TODO: this is fragile, it probably depends on the NS version
-        $Result.Count | Should Be 6
-    }
-    
-    It "should list builtin rewrite actions" {
-        $Result = Get-NSRewriteAction -ShowBuiltin
-        
-        $Result | Should Not BeNullOrEmpty
-        # TODO: this is fragile, it probably depends on the NS version
-        $Result.Count | Should Be 45
-    }
-
-    It "should list builtin rewrite policies" {
-        $Result = Get-NSRewritePolicy -ShowBuiltin
-        
-        $Result | Should Not BeNullOrEmpty
-        # TODO: this is fragile, it probably depends on the NS version
-        $Result.Count | Should Be 49
+        $Cert.certkey | Should Match "ns-server-certificate|ns-sftrust-certificate"
     }
 }
 
 Describe "Netscaler" {
-    $Session = Connect-Netscaler -Hostname $Nsip -Credential $Credential -PassThru
+    $Session = Connect-TestNetscaler
 
-        
     It "should add a LB server" {
         New-NSLBServer -Name 'srv-test' -IPAddress 1.2.3.4
-        
-        Compare-NSConfig $OldConf | Should Match "=> add server srv-test 1.2.3.4"       
+
+        Compare-NSConfig $OldConf | Should Match "=> add server srv-test 1.2.3.4"
     }
-    
-    BeforeEach { $OldConf = Get-NSConfig }    
-    AfterEach { Clear-NSConfig -Force }        
+
+    It "should add features" {
+        Enable-NSFeature -Force -Name "aaa", "lb", "rewrite", "ssl"
+
+        Compare-NSConfig $OldConf | Should Match "=> enable ns feature LB SSL AAA REWRITE"
+    }
+
+    BeforeEach { $OldConf = Get-NSConfig }
+    AfterEach { 
+        Clear-NSConfig -Force -Level Full 
+        # Web Logging and Surge Protection are not disabled by a config clear...
+        "wl", "sp" | Disable-NSFeature -Force
+    }
 }

--- a/ITTests/Simple.ITTests.ps1
+++ b/ITTests/Simple.ITTests.ps1
@@ -52,13 +52,37 @@ Describe "Netscaler Get-*" {
         $Cert | Should Not BeNullOrEmpty
         $Cert.certkey | Should Be "ns-server-certificate"
     }
+    
+    It "should list builtin responder policies" {
+        $Result = Get-NSResponderPolicy -ShowBuiltin
+        
+        $Result | Should Not BeNullOrEmpty
+        # TODO: this is fragile, it probably depends on the NS version
+        $Result.Count | Should Be 6
+    }
+    
+    It "should list builtin rewrite actions" {
+        $Result = Get-NSRewriteAction -ShowBuiltin
+        
+        $Result | Should Not BeNullOrEmpty
+        # TODO: this is fragile, it probably depends on the NS version
+        $Result.Count | Should Be 45
+    }
+
+    It "should list builtin rewrite policies" {
+        $Result = Get-NSRewritePolicy -ShowBuiltin
+        
+        $Result | Should Not BeNullOrEmpty
+        # TODO: this is fragile, it probably depends on the NS version
+        $Result.Count | Should Be 49
+    }
 }
 
 Describe "Netscaler" {
     $Session = Connect-Netscaler -Hostname $Nsip -Credential $Credential -PassThru
 
         
-    It "should add a server" {
+    It "should add a LB server" {
         New-NSLBServer -Name 'srv-test' -IPAddress 1.2.3.4
         
         Compare-NSConfig $OldConf | Should Match "=> add server srv-test 1.2.3.4"       

--- a/ITTests/Simple.ITTests.ps1
+++ b/ITTests/Simple.ITTests.ps1
@@ -1,4 +1,4 @@
-$Nsip              = "172.16.124.10"
+$Nsip              = "172.16.124.11"
 $Username          = "nsroot"
 $Password          = "nsroot"
 

--- a/ITTests/Simple.ITTests.ps1
+++ b/ITTests/Simple.ITTests.ps1
@@ -11,7 +11,7 @@ Describe "Netscaler Connection" {
 
             Get-NSHostname
             Disconnect-Netscaler
-            { Get-NSHostname } | Should Throw "401 (Unauthorized)"
+            { Get-NSHostname } | Should Throw "Unauthorized"
         }
 
         It "should disconnect explicit session" {
@@ -19,7 +19,7 @@ Describe "Netscaler Connection" {
 
             Get-NSHostname -Session $Session
             Disconnect-Netscaler -Session $Session
-            { Get-NSHostname -Session $Session } | Should Throw "401 (Unauthorized)"
+            { Get-NSHostname -Session $Session } | Should Throw "Unauthorized"
         }
     }
 

--- a/ITTests/Simple.ITTests.ps1
+++ b/ITTests/Simple.ITTests.ps1
@@ -1,0 +1,69 @@
+$Nsip              = "172.16.124.10"
+$Username          = "nsroot"
+$Password          = "nsroot"
+
+Import-Module Pester
+
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Import-Module -Force $here\..\Netscaler
+. $here\TestSupport.ps1
+
+Describe "Netscaler Get-*" {
+    $Session = Connect-Netscaler -Hostname $Nsip -Credential $Credential -PassThru
+
+    It "should list VPN policies" {
+        $Policy = Get-NSVPNSessionPolicy
+        
+        $Policy | Should Not BeNullOrEmpty
+        $Policy.name | Should Be "SETVPNPARAMS_POL" 
+    }
+
+    It "should get VPN policy" {
+        $Policy = Get-NSVPNSessionPolicy -Name "SETVPNPARAMS_POL"
+        
+        $Policy | Should Not BeNullOrEmpty
+        $Policy.name | Should Be "SETVPNPARAMS_POL"
+    }
+
+    It "should list VPN profiles" {
+        $Policy = Get-NSVPNSessionProfile
+        
+        $Policy | Should Not BeNullOrEmpty
+        $Policy.name | Should Be "SETVPNPARAMS_ACT" 
+    }
+
+    It "should get VPN profiles" {
+        $Policy = Get-NSVPNSessionProfile -Name "SETVPNPARAMS_ACT"
+        
+        $Policy | Should Not BeNullOrEmpty
+        $Policy.name | Should Be "SETVPNPARAMS_ACT"
+    }
+    
+    It "should get a certificate" {
+        $Cert = Get-NSSSLCertificate -Name "ns-server-certificate"
+
+        $Cert | Should Not BeNullOrEmpty
+        $Cert.certkey | Should Be "ns-server-certificate"
+    }
+
+    It "should list certificates" {
+        $Cert = Get-NSSSLCertificate
+
+        $Cert | Should Not BeNullOrEmpty
+        $Cert.certkey | Should Be "ns-server-certificate"
+    }
+}
+
+Describe "Netscaler" {
+    $Session = Connect-Netscaler -Hostname $Nsip -Credential $Credential -PassThru
+
+        
+    It "should add a server" {
+        New-NSLBServer -Name 'srv-test' -IPAddress 1.2.3.4
+        
+        Compare-NSConfig $OldConf | Should Match "=> add server srv-test 1.2.3.4"       
+    }
+    
+    BeforeEach { $OldConf = Get-NSConfig }    
+    AfterEach { Clear-NSConfig -Force }        
+}

--- a/ITTests/TestSupport.ps1
+++ b/ITTests/TestSupport.ps1
@@ -1,11 +1,17 @@
-$SecurePassword = ConvertTo-SecureString $Password -AsPlainText -Force
-$Credential = New-Object System.Management.Automation.PSCredential ($Username, $SecurePassword)    
+$TestNsip              = $(if ($env:TEST_NSIP) { $env:TEST_NSIP } else { "172.16.124.10" })
+$TestUsername          = "nsroot"
+$TestPassword          = "nsroot"
 
+function Connect-TestNetscaler {
+    $SecurePassword = ConvertTo-SecureString $TestPassword -AsPlainText -Force
+    $Credential = New-Object System.Management.Automation.PSCredential ($TestUsername, $SecurePassword)    
+    Connect-Netscaler -Hostname $TestNsip -Credential $Credential -PassThru   
+}
 
 function Compare-NSConfig($Old, $New = $(Get-NSConfig)) {
-    $Old = $Old | ? { Test-IsMutatingConfigLines $_ }
-    $New = $New | ? { Test-IsMutatingConfigLines $_ }
-    Compare-Object $Old $New | % {
+    $Old = $Old | Where-Object { Test-IsMutatingConfigLines $_ }
+    $New = $New | Where-Object { Test-IsMutatingConfigLines $_ }
+    Compare-Object $Old $New | ForEach-Object {
         "{0} {1}" -f $_.SideIndicator, $_.InputObject
     }
 }

--- a/ITTests/TestSupport.ps1
+++ b/ITTests/TestSupport.ps1
@@ -1,0 +1,15 @@
+$SecurePassword = ConvertTo-SecureString $Password -AsPlainText -Force
+$Credential = New-Object System.Management.Automation.PSCredential ($Username, $SecurePassword)    
+
+
+function Compare-NSConfig($Old, $New = $(Get-NSConfig)) {
+    $Old = $Old | ? { Test-IsMutatingConfigLines $_ }
+    $New = $New | ? { Test-IsMutatingConfigLines $_ }
+    Compare-Object $Old $New | % {
+        "{0} {1}" -f $_.SideIndicator, $_.InputObject
+    }
+}
+
+function Test-IsMutatingConfigLines($line) {
+    !($_ -match "^set (ns encryptionParams|cluster rsskey|ns rpcNode)")
+}

--- a/NetScaler/NetScaler.psm1
+++ b/NetScaler/NetScaler.psm1
@@ -18,7 +18,6 @@ limitations under the License.
 Set-StrictMode -Version 3
 
 $script:session = $null
-$script:protocol = $null
 
 # Load DLLs
 #$dll1 = Resolve-Path -Path "$PSScriptRoot\DLL\Newtonsoft.Json.dll"

--- a/NetScaler/Private/_InvokeNSRestApi.ps1
+++ b/NetScaler/Private/_InvokeNSRestApi.ps1
@@ -63,9 +63,9 @@ function _InvokeNSRestApi {
     )
 
     if ($Stat) {
-        $uri = "$($Script:protocol)://$($Session.Endpoint)/nitro/v1/stat/$Type"
+        $uri = $Session.CreateUri("stat", $Type)
     } else {
-        $uri = "$($Script:protocol)://$($Session.Endpoint)/nitro/v1/config/$Type"
+        $uri = $Session.CreateUri("config", $Type)
     }
 
     if (-not [string]::IsNullOrEmpty($Resource)) {

--- a/NetScaler/Public/Add-NSIPResource.ps1
+++ b/NetScaler/Public/Add-NSIPResource.ps1
@@ -74,7 +74,6 @@ function Add-NSIPResource {
     #>
     [cmdletbinding(SupportsShouldProcess = $true, ConfirmImpact='Low')]
     param(
-        [parameter(Mandatory)]
         $Session = $script:session,
 
         [parameter(Mandatory)]

--- a/NetScaler/Public/Disable-NSFeature.ps1
+++ b/NetScaler/Public/Disable-NSFeature.ps1
@@ -48,8 +48,8 @@ function Disable-NSFeature {
     param(
         $Session = $script:session,
 
-        [parameter(Mandatory,ValueFromPipeline = $true, ValueFromPipelineByPropertyName)]
-        [string[]]$Name = (Read-Host -Prompt 'NetScaler feature'),
+        [parameter(Mandatory, ValueFromPipeline = $true, ValueFromPipelineByPropertyName)]
+        [string[]]$Name,
 
         [switch]$Force,
 

--- a/NetScaler/Public/Disconnect-NetScaler.ps1
+++ b/NetScaler/Public/Disconnect-NetScaler.ps1
@@ -45,7 +45,7 @@ function Disconnect-NetScaler {
     try {
         Write-Verbose -Message 'Logging out of NetScaler'
         $params = @{
-            Uri =  "$($script:protocol)://$($Session.Endpoint)/nitro/v1/config/logout"
+            Uri = $Session.CreateUri("config", "logout")
             Body = ConvertTo-Json -InputObject @{logout = @{}}
             Method = 'POST'
             ContentType = 'application/json'

--- a/NetScaler/Public/Restart-NetScaler.ps1
+++ b/NetScaler/Public/Restart-NetScaler.ps1
@@ -119,7 +119,7 @@ function Restart-NetScaler {
                         $response = $null
                         try {
                             $params = @{
-                                Uri = "$($script:protocol)://$ip/nitro/v1/config"
+                                Uri = $Session.CreateUri("config")
                                 Method = 'GET'
                                 ContentType = 'application/json'
                                 ErrorVariable = 'connectTestError'

--- a/NetScaler/Public/Restart-NetScaler.ps1
+++ b/NetScaler/Public/Restart-NetScaler.ps1
@@ -67,7 +67,6 @@ function Restart-NetScaler {
     #>
     [cmdletbinding(SupportsShouldProcess = $true, ConfirmImpact='High')]
     param(
-        [parameter(Mandatory)]
         $Session = $script:session,
 
         [switch]$SaveConfig,

--- a/NetScaler/Public/Set-NSHostname.ps1
+++ b/NetScaler/Public/Set-NSHostname.ps1
@@ -46,7 +46,6 @@ function Set-NSHostname {
     #>
     [cmdletbinding(SupportsShouldProcess = $true, ConfirmImpact='high')]
     param(
-        [parameter(Mandatory)]
         $Session = $script:session,
 
         [parameter(Mandatory)]

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,24 @@
+# Integration testing
+
+## Setup a test netscaler
+
+    $Nsip       = "172.16.124.11"
+    $Snip       = "172.16.124.111"
+    $DnsIp      = "172.16.124.1"
+    $SubnetMask = "255.255.255.0"
+
+
+    $SecurePassword = ConvertTo-SecureString "nsroot" -AsPlainText -Force
+    $Credential = New-Object System.Management.Automation.PSCredential ("nsroot", $SecurePassword)
+    Connect-Netscaler -Hostname $Nsip -Credential $Credential
+    Add-NSIPResource -Type SNIP -IPAddress $Snip -SubnetMask $SubnetMask
+    Set-NSHostname -Hostname ns-test -Force
+    Add-NSDnsNameServer -IPAddress $DnsIp
+    Set-NSTimeZone -TimeZone "GMT+01:00-CET-Europe/Paris" -Force
+    Save-NSConfig
+    (Invoke-Nitro -Action get -Type nshardware -Method get).nshardware.Hostname
+
+    # Get a license with the _Host ID_
+
+    Install-NSLicense -Path /Users/dom/Downloads/FID__26d05285_157049a9857_1935.lic -Session $Session
+    Restart-NetScaler -Force

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,26 +1,75 @@
 # Integration testing
 
-## Setup a test netscaler
+## Provisioning
+
+In the following process we assume that the NetScaler _Host ID_ (first MAC address), the _NSIP_ are set in the following variables:
+
+    $HostId     = "000c296641f6"
+    $Nsip       = "172.16.124.11"
+    $DefaultGw  = "172.16.124.1"
+
+### Download & License
+
+1. Go to https://www.citrix.com/lp/try/netscaler-vpx-platinum.html to generate a license.
+1. Go to https://www.citrix.com/content/citrix/en_us/account/toolbox/manage-licenses/allocate.html to activate the license with the NetScaler _Host ID_.
+1. Download the license file and save it as license.lic
+1. Download the VPX package for your target hypervisor
+
+### VMWare Fusion
+
+The following setup instructions assume MacOSX with VMWare Fusion, but it can easily be
+adjusted to your own environment.
+
+1. Download _NetScaler VPX Express_ from https://www.citrix.com/downloads/netscaler-adc/ (a
+log in is required, just create a Citrix account)
+1. Unzip the downloaded file:
+        unzip -x NSVPX-ESX-11.0-69.12_nc.zip -d NSVPX-ESX-11.0-69.12_nc
+1. Import either with the VMWare GUI or, if you have OVF tools installed with:
+        ovftool --hideEula NSVPX-ESX-11.0-69.12_nc/NSVPX-ESX-11.0-69.12_nc.ovf ~/Documents/Virtual\ Machines.localized/
+        vmrun start ~/Documents/Virtual\ Machines.localized/NSVPX-ESX-11.0-69.12_nc.vmwarevm
+1. NetScaler should start and after a few seconds you will see the CLI setup wizard.
+Enter the IP address you will use to communicate with NetScaler, netmask and default
+gateway (ensure the proper VMWare network is configured for the VM).
+1. After a few seconds, check that you have access:
+        Connect-NetScaler -Hostname <insert IP address here> -Credential (Get-Credential -UserName nsroot)
+        Get-NSIPResource
+
+### Hyper-V 
+
+You can use the [New-NSHyperVInstance.ps1](https://github.com/dbroeglin/NetScaler/blob/exp/hyper-auto-provision/Contrib/New-NSHyperVInstance.ps1) to automatically setup a test instance with a single network inteface connected to the `Labnet` virtual switch:
+
+    New-NSHyperVInstance.ps1 -Verbose -Package C:\temp\NSVPX-HyperV-11.1-50.10_nc.zip `
+        -VMName NSVPX-11-1 `
+        -SwitchName Labnet `
+        -MacAddress $HostId `
+        -NSIP $Nsip -DefaultGateway $DefaultGateway `
+        -Path C:\temp\NSVPX-11-1 `
+
+### Other hypervisors
+
+TODO
+
+## Setup a test NetScaler
 
 The following commands achieve a minimal NetScaler setup for testing purposes.
 
-    $Nsip       = "172.16.124.11"
     $Snip       = "172.16.124.111"
     $DnsIp      = "172.16.124.1"
     $SubnetMask = "255.255.255.0"
 
-
     $SecurePassword = ConvertTo-SecureString "nsroot" -AsPlainText -Force
     $Credential = New-Object System.Management.Automation.PSCredential ("nsroot", $SecurePassword)
-    Connect-Netscaler -Hostname $Nsip -Credential $Credential
+    Connect-NetScaler -Hostname $Nsip -Credential $Credential
     Add-NSIPResource -Type SNIP -IPAddress $Snip -SubnetMask $SubnetMask
     Set-NSHostname -Hostname ns-test -Force
     Add-NSDnsNameServer -IPAddress $DnsIp
     Set-NSTimeZone -TimeZone "GMT+01:00-CET-Europe/Paris" -Force
     Save-NSConfig
+
+    # To retrieve the host ID if you did not set it during provisioning:
     (Get-NSHardware).host
 
-    # Get a license with the _Host ID_
-
-    Install-NSLicense -Path /Users/dom/Downloads/my_downloaded_license.lic -Session $Session
+    Install-NSLicense -Path $HOME/Downloads/my_downloaded_license.lic -Session $Session
     Restart-NetScaler -Force -Wait
+
+

--- a/TESTING.md
+++ b/TESTING.md
@@ -2,6 +2,8 @@
 
 ## Setup a test netscaler
 
+The following commands achieve a minimal NetScaler setup for testing purposes.
+
     $Nsip       = "172.16.124.11"
     $Snip       = "172.16.124.111"
     $DnsIp      = "172.16.124.1"
@@ -16,9 +18,9 @@
     Add-NSDnsNameServer -IPAddress $DnsIp
     Set-NSTimeZone -TimeZone "GMT+01:00-CET-Europe/Paris" -Force
     Save-NSConfig
-    (Invoke-Nitro -Action get -Type nshardware -Method get).nshardware.Hostname
+    (Get-NSHardware).host
 
     # Get a license with the _Host ID_
 
-    Install-NSLicense -Path /Users/dom/Downloads/FID__26d05285_157049a9857_1935.lic -Session $Session
-    Restart-NetScaler -Force
+    Install-NSLicense -Path /Users/dom/Downloads/my_downloaded_license.lic -Session $Session
+    Restart-NetScaler -Force -Wait

--- a/Tests/Unit/Public/Connect-NetScaler.tests.ps1
+++ b/Tests/Unit/Public/Connect-NetScaler.tests.ps1
@@ -29,9 +29,14 @@ describe 'Connect-NetScaler' {
                 $script:session | should not benullorempty
             }
 
+            it 'Connects via HTTP' {
+                Connect-NetScaler -Hostname 'localhost' -Credential $credential
+                $script:session.scheme | should be 'http'
+            }
+
             it 'Connects via HTTPs' {
                 Connect-NetScaler -Hostname 'localhost' -Credential $credential -HTTPs
-                $script:protocol | should be 'https'
+                $script:session.scheme | should be 'https'
             }
         }
 


### PR DESCRIPTION
## Description
Fixed the URI protocol (renamed it to scheme which is the usual name in a URI) scope issue by adding it to the NS session object. Also added a `Uri` script property to the object that returns the URI prefix and a `CreateUri()` method that help prevent URI generation duplication throughout the module's code.

I hope you will not find me too _cavalier_ but, as the changes impact quite a few methods, I put the changes on top of the integration testing branch I created before. My hope is that it will ensure I did not introduce any regressions. 

The current state of the IT tests is not satisfactory. If you agree to bring them in, I will work on having better documentation, better integration in the development workflow and as much automated setup as possible for the tests.

For now they can be run with the following command:

```
Invoke-Pester  -Script ./ITTests/Simple.ITTests.ps1
```

## Related Issue

#76

## Motivation and Context
Fixing an issue. 

The IT tests are required if we want to automate testing of the module's behaviour beyond what can be done with mocks.

## How Has This Been Tested?

- The unit tests where run on Win2016.
- The IT tests where run on Win2016 and MacOSX
- `Restart-Netscaler` was tested manually on Win2016

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
