### PR TITLE
Added Remove-NSSystemFile

### DIFF
--- a/NetScaler/NetScaler.psd1
+++ b/NetScaler/NetScaler.psd1
@@ -185,6 +185,7 @@ FunctionsToExport = @(
     'Remove-NSResponderAction',
     'Remove-NSSSLCertificateLink',
     'Remove-NSSSLProfile',
+    'Remove-NSSystemFile',
     'Remove-NSVPNSessionPolicy',
     'Remove-NSVPNSessionProfile',
     'Restart-NetScaler',

--- a/NetScaler/Public/Remove-NSSystemFile.ps1
+++ b/NetScaler/Public/Remove-NSSystemFile.ps1
@@ -1,0 +1,58 @@
+﻿<#
+Copyright 2016 Dominique Broeglin
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+#>
+
+function Remove-NSSystemFile {
+    <#
+    .SYNOPSIS
+        Removes the specified system file object(s).
+
+    .DESCRIPTION
+        Removes the specified system file object(s).
+
+    .EXAMPLE
+        Get-NSSystemFile -Filename "foo.txt" -FileLocation "/foo/bar"
+    
+        Removes the file "/foo/bar/foo.txt"
+
+    .PARAMETER Session
+        The NetScaler session object.
+
+    .PARAMETER Filename
+        Name of the file.
+
+    .PARAMETER FileLocation
+        Location of the file.
+    #>
+    [CmdletBinding(DefaultParameterSetName='get')]
+    param(
+        $Session = $Script:Session,
+
+        [Parameter(Mandatory)]
+        [string]$Filename,
+
+        [Parameter(Mandatory)]
+        [string]$FileLocation
+    )
+
+    begin {
+        _AssertSessionActive
+    }
+
+    process {
+        $Arguments = @{ 'filename' = $Filename; 'filelocation' = $FileLocation }
+        _InvokeNSRestApi -Session $Session -Type systemfile -Arguments $Arguments -Method DELETE
+    }
+}

--- a/NetScaler/Public/Remove-NSSystemFile.ps1
+++ b/NetScaler/Public/Remove-NSSystemFile.ps1
@@ -58,7 +58,7 @@ function Remove-NSSystemFile {
 
     process {
         $fileFullPath = "$FileLocation/$Filename"
-        if ($Force -or $PSCmdlet.ShouldProcess($fileFullPath, "Remove file: $fileFullPath")) {
+        if ($Force -or $PSCmdlet.ShouldProcess($fileFullPath, "Remove file")) {
             $Arguments = @{ 'filename' = $Filename; 'filelocation' = $FileLocation }
             _InvokeNSRestApi -Session $Session -Type systemfile -Arguments $Arguments -Method DELETE
         }

--- a/NetScaler/Public/Remove-NSSystemFile.ps1
+++ b/NetScaler/Public/Remove-NSSystemFile.ps1
@@ -23,7 +23,7 @@ function Remove-NSSystemFile {
         Removes the specified system file object(s).
 
     .EXAMPLE
-        Get-NSSystemFile -Filename "foo.txt" -FileLocation "/foo/bar"
+        Remove-NSSystemFile -Filename "foo.txt" -FileLocation "/foo/bar"
     
         Removes the file "/foo/bar/foo.txt"
 

--- a/NetScaler/Public/Remove-NSSystemFile.ps1
+++ b/NetScaler/Public/Remove-NSSystemFile.ps1
@@ -35,8 +35,11 @@ function Remove-NSSystemFile {
 
     .PARAMETER FileLocation
         Location of the file.
+
+    .PARAMETER Force
+        Suppress confirmation when deleting the file.
     #>
-    [CmdletBinding(DefaultParameterSetName='get')]
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact='High')]
     param(
         $Session = $Script:Session,
 
@@ -44,7 +47,9 @@ function Remove-NSSystemFile {
         [string]$Filename,
 
         [Parameter(Mandatory)]
-        [string]$FileLocation
+        [string]$FileLocation,
+
+        [switch]$Force
     )
 
     begin {
@@ -52,7 +57,10 @@ function Remove-NSSystemFile {
     }
 
     process {
-        $Arguments = @{ 'filename' = $Filename; 'filelocation' = $FileLocation }
-        _InvokeNSRestApi -Session $Session -Type systemfile -Arguments $Arguments -Method DELETE
+        $fileFullPath = "$FileLocation/$Filename"
+        if ($Force -or $PSCmdlet.ShouldProcess($fileFullPath, "Remove file: $fileFullPath")) {
+            $Arguments = @{ 'filename' = $Filename; 'filelocation' = $FileLocation }
+            _InvokeNSRestApi -Session $Session -Type systemfile -Arguments $Arguments -Method DELETE
+        }
     }
 }


### PR DESCRIPTION
Added Remove-NSSystemFile: removes a given file from NetScaler's filesytem

## Description
New function `Remove-NSSystemFile` was added. It deletes a specified file from the NetScaler device.

## Related Issue
https://github.com/devblackops/NetScaler/issues/80

## Motivation and Context
This function, together with `Add-NSSystemFile` and `Get-NSSystemFile`, provides full support for NetScaler's filesystem manipulation.

## How Has This Been Tested?
Tested on NetScaler version NS12.0 41.16.nc

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
