### PR TITLE
Adds SearchFilter and SubAttributeName to New-NSLDAPAuthenticationServer

### DIFF
--- a/NetScaler/Public/New-NSLDAPAuthenticationServer.ps1
+++ b/NetScaler/Public/New-NSLDAPAuthenticationServer.ps1
@@ -60,8 +60,14 @@ function New-NSLDAPAuthenticationServer {
     .PARAMETER LoginAttributeName
         LDAP login name attribute. The NetScaler appliance uses the LDAP login name to query external LDAP servers or Active Directories
 
+    .PARAMETER SearchFilter
+        String to be combined with the default LDAP user search string to form the search value.
+
     .PARAMETER GroupAttributeName
         LDAP group attribute name used for group extraction on the LDAP server.
+
+    .PARAMETER SubAttributeName
+        LDAP group sub-attribute name. Used for group extraction from the LDAP server.
 
     .PARAMETER SSOAttributeName
         LDAP single signon (SSO) attribute. The NetScaler appliance uses the SSO name attribute to query external LDAP servers or Active Directory for an alternate username.
@@ -106,7 +112,11 @@ function New-NSLDAPAuthenticationServer {
 
         [string] $LoginAttributeName,
 
+        [string] $SearchFilter,
+
         [string] $GroupAttributeName,
+
+        [string] $SubAttributeName,
 
         [string] $SSOAttributeName,
 
@@ -142,8 +152,14 @@ function New-NSLDAPAuthenticationServer {
                 if ($PSBoundParameters.ContainsKey('LoginAttributeName')) {
                     $params.Add('ldaploginname', $LoginAttributeName)
                 }
+                if ($PSBoundParameters.ContainsKey('SearchFilter')) {
+                    $params.Add('searchfilter', $SearchFilter)
+                }
                 if ($PSBoundParameters.ContainsKey('GroupAttributeName')) {
                     $params.Add('groupattrname', $GroupAttributeName)
+                }
+                if ($PSBoundParameters.ContainsKey('SubAttributeName')) {
+                    $params.Add('subattributename', $SubAttributeName)
                 }
                 if ($PSBoundParameters.ContainsKey('SecurityType')) {
                     $params.Add('sectype', $SecurityType)


### PR DESCRIPTION
## Description
Adds SearchFilter and SubAttributeName parameters to the New-NSLDAPAuthenticationServer cmdlet

## Related Issue
Fixes #87

## Motivation and Context
Restricting access to NetScaler Gateway virtual servers requires configuring an LDAP search filter. This update adds the missing 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Redeployed a scripted NetScaler appliance and manually ran the unit tests.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
