### PR TITLE
Add Delay option

### DIFF
--- a/NetScaler/Public/Disable-NSLBServer.ps1
+++ b/NetScaler/Public/Disable-NSLBServer.ps1
@@ -49,7 +49,7 @@ function Disable-NSLBServer {
         The name or names of the load balancer servers to disable.
 
     .PARAMETER Graceful
-        Indicates graceful shutdown of the server. System will wait for all outstanding connections to this server to be closed before disabling the server.
+        Does a graceful shutdown of the server after the number of seconds. System will wait for all outstanding connections to this server to be closed before disabling the server.
 
     .PARAMETER Delay
         How many seconds to wait before disabling this server.
@@ -67,8 +67,10 @@ function Disable-NSLBServer {
         [parameter(Mandatory,ValueFromPipeline = $true, ValueFromPipelineByPropertyName)]
         [string[]]$Name = (Read-Host -Prompt 'LB server name'),
         
+        [Parameter(ParameterSetName="Delay")]
         [int]$Delay,
 
+        [Parameter(ParameterSetName="Graceful")]
         [int]$Graceful,
         
         [switch]$Force,
@@ -89,21 +91,10 @@ function Disable-NSLBServer {
                     }
                     if ($PSBoundParameters.ContainsKey('Graceful')) {
                         $params.Add('graceful', 'YES')
-                        if ($Graceful -gt 0) {
-                            $params.Add('delay', $Graceful)
-                        } else {
-                            if ($PSBoundParameters.ContainsKey('Delay')) {
-                                $params.Add('delay', $Delay)
-                            } else {
-                                $params.Add('delay', 0)
-                            }
-                        }
-                    } else {
-                        if ($PSBoundParameters.ContainsKey('Delay')) {
-                            if ($Delay -gt 0) {
-                                $params.Add('delay', $Delay)
-                            }
-                        }
+                        $params.Add('delay', $Graceful)
+                    }
+                    if ($PSBoundParameters.ContainsKey('Delay')) {
+                        $params.Add('delay', $Delay)
                     }
                     _InvokeNSRestApi -Session $Session -Method POST -Type server -Payload $params -Action disable
 

--- a/NetScaler/Public/Disable-NSLBServer.ps1
+++ b/NetScaler/Public/Disable-NSLBServer.ps1
@@ -38,7 +38,7 @@ function Disable-NSLBServer {
         Disable the load balancer server 'server01' without confirmation and return the resulting object.
 
     .EXAMPLE
-        $server = Disable-NSLBServer -Name 'server01' -Graceful 60 -Force -PassThru
+        $server = Disable-NSLBServer -Name 'server01' -Graceful -Delay 60 -Force -PassThru
 
         Disable the load balancer server 'server01' without confirmation, giving a 60 second grace period before disabling and return the resulting object.
 
@@ -49,7 +49,10 @@ function Disable-NSLBServer {
         The name or names of the load balancer servers to disable.
 
     .PARAMETER Graceful
-        Indicates graceful shutdown of the server. System will wait for all outstanding connections to this server to be closed before disabling the server. Wait time in seconds may be included before disabling happens.
+        Indicates graceful shutdown of the server. System will wait for all outstanding connections to this server to be closed before disabling the server.
+
+    .PARAMETER Delay
+        How many seconds to wait before disabling this server.
 
     .PARAMETER Force
         Suppress confirmation when disabling the server.
@@ -64,6 +67,8 @@ function Disable-NSLBServer {
         [parameter(Mandatory,ValueFromPipeline = $true, ValueFromPipelineByPropertyName)]
         [string[]]$Name = (Read-Host -Prompt 'LB server name'),
         
+        [int]$Delay,
+
         [int]$Graceful,
         
         [switch]$Force,
@@ -87,7 +92,17 @@ function Disable-NSLBServer {
                         if ($Graceful -gt 0) {
                             $params.Add('delay', $Graceful)
                         } else {
-                            $params.Add('delay', 0)
+                            if ($PSBoundParameters.ContainsKey('Delay')) {
+                                $params.Add('delay', $Delay)
+                            } else {
+                                $params.Add('delay', 0)
+                            }
+                        }
+                    } else {
+                        if ($PSBoundParameters.ContainsKey('Delay')) {
+                            if ($Delay -gt 0) {
+                                $params.Add('delay', $Delay)
+                            }
                         }
                     }
                     _InvokeNSRestApi -Session $Session -Method POST -Type server -Payload $params -Action disable


### PR DESCRIPTION
Added Delay option to give number of seconds before disabling a server.
Changed Graceful option to use the Delay value if present on the command.

## Description
Added -Delay option to the command that will give the number of seconds before disabling a server.  Also changed the -Graceful to use the value supplied by a Delay.

## Related Issue
https://github.com/devblackops/NetScaler/issues/98

## Motivation and Context
Adding a missing option that is part of the Nitro API.

## How Has This Been Tested?
I ran the updated version of this cmdlet against several of our NetScalers to disable servers.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
