### PR TITLE
Fixed Get-NSLBVirtualServerBinding to also retrieve service_binding objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
   * Bug fixes
     * Fixed bug where extraneous Out-Null files were created when calling some functions (via @iainbrighton)
+    * Fixed bug where Get-NSLBVirtualServerBinding didn't return lbvserver_service_binding objects (via @myllyja)
 
 ## 1.7.0 (2018-07-02)
   * Features

--- a/NetScaler/Public/Get-NSLBVirtualServerBinding.ps1
+++ b/NetScaler/Public/Get-NSLBVirtualServerBinding.ps1
@@ -71,14 +71,19 @@ function Get-NSLBVirtualServerBinding {
         } else {
             $vServers = Get-NSLBVirtualServer -Session $Session -Verbose:$false
             foreach ($item in $vServers) {
-                $response = _InvokeNSRestApi -Session $Session -Method Get -Type lbvserver_servicegroup_binding -Resource $item.name
-                if ($response.errorcode -ne 0) { throw $bindings }
-                if ($response.PSobject.Properties.name -contains 'lbvserver_servicegroup_binding') {
-                    $result += $response.lbvserver_servicegroup_binding
-                }
-                if ($response.PSobject.Properties.name -contains 'lbvserver_service_binding') {
-                    $result += $response.lbvserver_service_binding
-                }
+                $response = @()
+                $response += _InvokeNSRestApi -Session $Session -Method Get -Type lbvserver_servicegroup_binding -Resource $item.name
+                if ($response.errorcode -ne 0) { throw $response }
+                $response += _InvokeNSRestApi -Session $Session -Method Get -Type lbvserver_service_binding -Resource $item.name
+
+                foreach ($entry in $response) {
+					if ($entry.PSobject.Properties.name -contains 'lbvserver_servicegroup_binding') {
+						$result += $entry.lbvserver_servicegroup_binding
+					}
+					if ($entry.PSobject.Properties.name -contains 'lbvserver_service_binding') {
+						$result += $entry.lbvserver_service_binding
+					}
+				}
             }
         }
         return $result

--- a/NetScaler/Public/Get-NSLBVirtualServerBinding.ps1
+++ b/NetScaler/Public/Get-NSLBVirtualServerBinding.ps1
@@ -77,13 +77,13 @@ function Get-NSLBVirtualServerBinding {
                 $response += _InvokeNSRestApi -Session $Session -Method Get -Type lbvserver_service_binding -Resource $item.name
 
                 foreach ($entry in $response) {
-					if ($entry.PSobject.Properties.name -contains 'lbvserver_servicegroup_binding') {
-						$result += $entry.lbvserver_servicegroup_binding
-					}
-					if ($entry.PSobject.Properties.name -contains 'lbvserver_service_binding') {
-						$result += $entry.lbvserver_service_binding
-					}
-				}
+                    if ($entry.PSobject.Properties.name -contains 'lbvserver_servicegroup_binding') {
+                        $result += $entry.lbvserver_servicegroup_binding
+                    }
+                    if ($entry.PSobject.Properties.name -contains 'lbvserver_service_binding') {
+                        $result += $entry.lbvserver_service_binding
+                    }
+                }
             }
         }
         return $result


### PR DESCRIPTION
## Description
Get-NSLBVirtualServerBinding was looking for lbvserver_servicegroup_binding and lbvserver_service_binding objects when called with the name parameter. Without the parameter is was only returning lbvserver_servicegroup_binding objects.

## Related Issue
#101

## Motivation and Context
Fixes a bug

## How Has This Been Tested?
Tested by editing this file locally and running the command with and without the name parameter. It now returns both types of bindings when called without the parameter.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
