### PR TITLE
Add function to get aaasession

### DIFF
--- a/NetScaler/NetScaler.psd1
+++ b/NetScaler/NetScaler.psd1
@@ -101,6 +101,7 @@ FunctionsToExport = @(
     'Enable-NSMode',
     'Get-NSAAAGroup',
     'Get-NSAAAGroupBinding',
+    'Get-NSAAASession'
     'Get-NSAAAUser',
     'Get-NSAAAUserBinding',
     'Get-NSAAAVirtualServer',

--- a/NetScaler/Public/Get-NSAAASession.ps1
+++ b/NetScaler/Public/Get-NSAAASession.ps1
@@ -1,0 +1,96 @@
+<#
+Copyright 2020 Nicolas Rogier
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+#>
+
+function Get-NSAAASession {
+    <#
+    .SYNOPSIS
+        Gets NetScaler AAA session(s).
+
+    .DESCRIPTION
+        Gets NetScaler AAA session(s). If no parameters are provided all AAA
+        sessions are returned. The 'Username' and 'Filter' parameters can be
+        used to select a specific session or a subset of sessions.
+
+    .EXAMPLE
+        Get-NSAAASession
+
+        Gets all AAA users.
+
+    .EXAMPLE
+        Get-NSAAASession -Username 'User1','User2','User3'
+
+        Gets AAA sessions for User1, User2, and User3.
+
+    .EXAMPLE
+        Get-NSAAASession -Filter 'ABC'
+
+        Gets all AAA sessions with 'ABC' in the username.
+
+    .PARAMETER Name
+        Defines the specific AAA session(s) to be returned.
+
+    .PARAMETER Filter
+        When specified, only sessions that username contain the
+        provided string are returned.
+
+    .PARAMETER Session
+        The NetScaler session object.
+    #>
+
+    [cmdletbinding()]
+    param(
+        [Parameter(
+            ValueFromPipeline = $true,
+            ValueFromPipelineByPropertyName = $true,
+            Position = 0)]
+        [alias('UserName')]
+        [string[]]$Name,
+        [string]$Filter,
+
+        $Session = $script:session
+    )
+
+    begin {
+        _AssertSessionActive
+    }
+
+    process {
+        Try {
+            $response = _InvokeNSRestApi -Session $Session -Method Get -Type aaasession -Action Get
+            if ($response.psobject.properties | Where-Object { $_.name -eq 'aaasession' }) {
+                if (-Not([string]::IsNullOrEmpty($Name))) {
+                    foreach ($User in $Name) {
+                        if ($response.aaasession | Where-Object { $_.username -eq $User }) {
+                            $response.aaasession | Where-Object { $_.username -eq $User }
+                        }
+                    }
+                } else {
+                    if (-Not([string]::IsNullOrEmpty($Filter))) {
+                        foreach ($item in $response.aaasession) {
+                            if ($item.username -match "$Filter") {
+                                $item
+                            }
+                        }
+                    } else {
+                        $response.aaasession
+                    }
+                }
+            }
+        } Catch {
+            Throw $_
+        }
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add function Get-NSAAASession to get NS AAA sessions.

With no parameter, all AAA sessions returned. The 'Username' and 'Filter' parameters can be used to select a specific session or a subset of sessions.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
For some use cases, I need to retrieve the sessions to then manipulate them.

## How Has This Been Tested?
```
$Hostname = 'hostname'
$Credential = Import-Clixml -Path .\cred.xml
$Session = Connect-NetScaler -Hostname $Hostname -Credential $Credential -Https -PassThru
$AAASessions = Get-NSAAASession -Session $Session
$AAAFilterSessions = Get-NSAAASession -Filter '^fr' -Session $Session
$AAAUserSessions = Get-NSAAASession -Name 'user1','user2' -Session $Session

$Users = 'user1', 'user2'
$Users | Get-NSAAASession -Session $Session
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
