### PR TITLE
Connect-NetScaler bug

### DIFF
--- a/NetScaler/Public/Connect-NetScaler.ps1
+++ b/NetScaler/Public/Connect-NetScaler.ps1
@@ -102,7 +102,14 @@ function Connect-NetScaler {
                 timeout = $Timeout
             }
         }
-        $loginJson = ConvertTo-Json -InputObject $login
+        $loginJson = ConvertTo-Json -InputObject $login | % {
+            [Regex]::Replace($_, 
+                "\\u(?<Value>[a-zA-Z0-9]{4})", {
+                    param($m) ([char]([int]::Parse($m.Groups['Value'].Value,
+                                [System.Globalization.NumberStyles]::HexNumber))).ToString() 
+                }
+            )
+        }
 
         $saveSession = @{}
         $params = @{


### PR DESCRIPTION
Connect-NetScaler breaks if username or password contains certain characters (e.g.: & (ampersand))

## Description
The function 'ConvertTo-JSON', which is used in 'Connect-NetScaler' converts these special characters to unicode escaped characters (e.g.: & = \\u0026). This addition to the code will unescape only unicode characters.

## Motivation and Context
Cannot log in when certain characters are used in username or password

## How Has This Been Tested?
I could not log in with a password containing an ampersand, now I can.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
